### PR TITLE
Allow Coding context in icd-10-gm-diagnosesicherheit

### DIFF
--- a/extensions/Extension-icd-10-gm-diagnosesicherheit.xml
+++ b/extensions/Extension-icd-10-gm-diagnosesicherheit.xml
@@ -22,6 +22,10 @@
     <type value="element" />
     <expression value="CodeableConcept.coding" />
   </context>
+  <context>
+    <type value="element" />
+    <expression value="Coding" />
+  </context>
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />


### PR DESCRIPTION
Wir verwenden in einem Projekt die ICD-10-GM-Extensions für Primärcode, Ausrufezeichen und Manifestationscode. Innerhalb dieser Extension haben wir bereits die Extension für die Seitenlokalisation eingebunden um diese separat je Code-Bestandteil erfassen zu können. Dies wollen wir auch für die Dagnosesicherheit. Bisher erlaubt die Diagnosesicherheit-Extension nicht das Verwenden an dieser Stelle. Dieser PR behebt dies.

Siehe Seitenlokalisation:
https://github.com/hl7germany/basisprofil-de-r4/blob/master/extensions/Extension-seitenlokalisation.xml

Genanntes Projekt:
https://simplifier.net/washabich/WhiEncounterParameters/~overview
