### PR TITLE
IKNR sollte auch “secondary” als use erlauben

### DIFF
--- a/datentypen-profile/Profile-identifier-iknr.xml
+++ b/datentypen-profile/Profile-identifier-iknr.xml
@@ -23,10 +23,6 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
   <derivation value="constraint" />
   <differential>
-    <element id="Identifier.use">
-      <path value="Identifier.use" />
-      <fixedCode value="official" />
-    </element>
     <element id="Identifier.type">
       <path value="Identifier.type" />
       <patternCodeableConcept>


### PR DESCRIPTION
Fixes #406 