### PR TITLE
Fixed kvid-2 invariant #598

### DIFF
--- a/resources/fsh-generated/resources/StructureDefinition-identifier-kvid-10.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-kvid-10.json
@@ -44,7 +44,7 @@
             "key": "kvid-2",
             "severity": "warning",
             "human": "Als Type sollte der Code 'KVZ10' verwendet werden, die Codes 'GKV' und 'PKV' haben den Status 'retired'",
-            "expression": "($this.identifier.type.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='GKV') or $this.identifier.type.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='PKV')).not()",
+            "expression": "($this.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='GKV') or $this.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='PKV')).not()",
             "source": "http://fhir.de/StructureDefinition/identifier-kvid-10"
           }
         ],

--- a/resources/input/fsh/invariants/kvid-2.fsh
+++ b/resources/input/fsh/invariants/kvid-2.fsh
@@ -1,4 +1,4 @@
 Invariant: kvid-2
 Description: "Als Type sollte der Code 'KVZ10' verwendet werden, die Codes 'GKV' und 'PKV' haben den Status 'retired'"
 Severity: #warning
-Expression: "($this.identifier.type.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='GKV') or $this.identifier.type.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='PKV')).not()"
+Expression: "($this.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='GKV') or $this.coding.exists(system='http://fhir.de/CodeSystem/identifier-type-de-basis' and code='PKV')).not()"


### PR DESCRIPTION
kvid-2 Invariante triggerte nicht im Kontext Identifier.type. Expression angepasst.

Test case -> [Fhirpath Lab](https://fhirpath-lab.azurewebsites.net/FhirPath/?expression=%28%24this.coding.exists%28system%3D%27http%3A%2F%2Ffhir.de%2FCodeSystem%2Fidentifier-type-de-basis%27%20and%20code%3D%27GKV%27%29%20or%20%24this.coding.exists%28system%3D%27http%3A%2F%2Ffhir.de%2FCodeSystem%2Fidentifier-type-de-basis%27%20and%20code%3D%27PKV%27%29%29.not%28%29&engine=java%20%28HAPI%29&context=Patient.identifier.type&resourceJson=N4KABGBEBOCmDOB7ArtAxrAKgTwA60gC4oAFAQwBcBLWAOwsgBpwoqATO6gMxuiLADaLCKAhioFPAWKjxYyGkRsqtAOb8hcubK3iFS6VADSANQBaARgAMTYboiR42eBVgBbfpAAWFCrkIA9AFcXlTQAHQcAQDCBgDKzq5uAeycVDyw0AC0kvhZHFkARmTwVPCQdloAvsz2IpW6%20hyeJKa2dfJOLu6ePn6BwaERUbEcCd3JqfTpvDlS%20bBFJWUVHVUNEAC6DTUNjok9xN6%20-kEhYZGwAaVsAaoA1gBuAU-sWdbtcpDI8IaQiFweGgqGQADafPSPMHIP4AcQAnPCAKxWADMViRADYAOyrMTrLYgdZAA&terminologyserver=https%3A%2F%2Fsqlonfhir-r4.azurewebsites.net%2Ffhir)