### PR TITLE
Update VitalSignDE_Koerpertemperatur_SNOMED_CT

### DIFF
--- a/ig/ImplementationGuide.json
+++ b/ig/ImplementationGuide.json
@@ -1,7 +1,7 @@
 {
     "resourceType": "ImplementationGuide",
     "url": "/guide/basisprofil-de-r4?version=current",
-    "version": "1.5.4",
+    "version": "1.6.0",
     "name": "Leitfaden Basis DE (R4)",
     "status": "draft",
     "description": "Die Leitfaden wird von der [Projektgruppe Basisprofilierung](http://wiki.hl7.de/index.php?title=FHIR-Basisprofilierung_(Projekt)) des [Technischen Komitees FHIR von HL7 Deutschland e.V.](http://hl7.de/technische-komitees/fhir/ ) erstellt.\n\nDie Diskussion der Inhalte findet auf [Zulip](https://chat.fhir.org/#narrow/stream/german.20(d-a-ch)) statt. \nImplementierer und Interessenten sind herzlich eingeladen, sich an der Diskussion zu beteiligen, Fragen zu stellen,\noder Feedback zu geben.\n\nDie Weiterentwicklung der deutschen Basisprofile kann im [GitHub-Repository](https://github.com/hl7germany/basisprofil-de-r4) verfolgt werden.\n\nVerbesserungs- und Korrekturvorschläge sollten ebenfalls über den [GitHub-Issue-Tracker](https://github.com/hl7germany/basisprofil-de-r4/issues) eingereicht werden.\n\n**Die neueste stabile Fassung findet sich unter http://ig.fhir.de/basisprofile-de/stable/**\n\nEine formelle Abstimmung folgt. Um über Kommentierungsphasen, anstehende Abstimmungen und aktuelle Themen informiert zu werden, registrieren Sie sich bitte für den FHIR-Newsletter durch formlose Mail an fhir@hl7.de.",

--- a/ig/markdown/Abrechnungsnummer.md
+++ b/ig/markdown/Abrechnungsnummer.md
@@ -1,6 +1,6 @@
 #### {{page-title}}
 
-**Name**: IdentifierAbrechnungsnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-abrechnungsnummer&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierAbrechnungsnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-abrechnungsnummer&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-abrechnungsnummer`
 
@@ -28,4 +28,4 @@ Beispiel:
     </identifier>
 ```
 
-Für den Aufnahmenummer Identifier (Encounter) ist folgendes Profil zu verwenden: ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-aufnahmenummer&scope=de.basisprofil.r4@1.5.4))
+Für den Aufnahmenummer Identifier (Encounter) ist folgendes Profil zu verwenden: ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-aufnahmenummer&scope=de.basisprofil.r4@1.6.0))

--- a/ig/markdown/Aufnahmenummer.md
+++ b/ig/markdown/Aufnahmenummer.md
@@ -1,6 +1,6 @@
 #### {{page-title}}
 
-**Name**: IdentifierAufnahmenummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-aufnahmenummer&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierAufnahmenummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-aufnahmenummer&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-aufnahmenummer`
 
@@ -28,4 +28,4 @@ Beispiel:
     </identifier>
 ```
 
-Für den Abrechnungsnummer Identifier (Account) ist folgendes Profil zu verwenden: ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-abrechnungsnummer&scope=de.basisprofil.r4@1.5.4))
+Für den Abrechnungsnummer Identifier (Account) ist folgendes Profil zu verwenden: ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-abrechnungsnummer&scope=de.basisprofil.r4@1.6.0))

--- a/ig/markdown/BetriebsstttennummerBSNR-Identifier.md
+++ b/ig/markdown/BetriebsstttennummerBSNR-Identifier.md
@@ -2,7 +2,7 @@
 
 Zur Abbildung einer [Betriebsstättennummer](https://www.kbv.de/media/sp/Arztnummern_Richtlinie.pdf) zur eindeutigen Identifizierung von Betriebstätten und Nebenbetriebsstätten kann folgendes Identifier-Profil verwendet werden:
 
-**Name**: IdentifierBsnr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-bsnr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierBsnr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-bsnr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-bsnr`
 

--- a/ig/markdown/Datentypen-Coding-ASK.md
+++ b/ig/markdown/Datentypen-Coding-ASK.md
@@ -3,7 +3,7 @@
 
 Bei der Kodierung per [ASK](https://www.bfarm.de/DE/Arzneimittel/Arzneimittelinformationen/Arzneimittel-recherchieren/Stoffbezeichnungen/Datenbankinformation-Stoffbezeichnungen/_node.html) muss das Element Condition.code mit mindestens einem Coding gefüllt sein, das den Anforderungen der ASK-Kodierung genügt. Hierzu sollte beim Einbinden des Coding-Profils in das entsprechende Use-Case-Profil ein Binding auf das ASK ValueSet hinzugefügt werden. Siehe {{pagelink:ig/markdown/Terminologie-ValueSets.md}}.
 
-**Name**: CodingASK ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingASK&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingASK ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingASK&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingASK`
 

--- a/ig/markdown/Datentypen-Coding-ATC.md
+++ b/ig/markdown/Datentypen-Coding-ATC.md
@@ -3,7 +3,7 @@
 
 Bei der Kodierung per [ATC](https://www.whocc.no/atc_ddd_index/) muss das Element Condition.code mit mindestens einem Coding gefüllt sein, das den Anforderungen der ATC-Kodierung genügt. Hierzu sollte beim Einbinden des Coding-Profils in das entsprechende Use-Case-Profil ein Binding auf das ATC ValueSet hinzugefügt werden. Siehe {{pagelink:ig/markdown/Terminologie-ValueSets.md}}.
 
-**Name**: CodingATC ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingATC&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingATC ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingATC&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingATC`
 

--- a/ig/markdown/Datentypen-Coding-Alpha-ID-SE.md
+++ b/ig/markdown/Datentypen-Coding-Alpha-ID-SE.md
@@ -5,7 +5,7 @@ Bei der Kodierung per [Alpha-ID-SE](https://www.bfarm.de/DE/Kodiersysteme/Termin
 
 Die Angabe der Alpha-ID-SE-Version (z.B."2019"), aus der ein Code stammt, ist verpflichtend, da die Alpha-ID-SE nicht versions-stabil ist, d.h. Codes können zwischen den unterschiedlichen Jahrensangaben in der Bedeutung wechseln.
 
-**Name**: CodingAlphaIDSE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingAlphaIDSE&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingAlphaIDSE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingAlphaIDSE&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingAlphaIDSE`
 

--- a/ig/markdown/Datentypen-Coding-Alpha-ID.md
+++ b/ig/markdown/Datentypen-Coding-Alpha-ID.md
@@ -5,7 +5,7 @@ Bei der Kodierung per [Alpha-ID](https://www.bfarm.de/DE/Kodiersysteme/Terminolo
 
 Die Angabe der Alpha-ID-Version (z.B."2019"), aus der ein Code stammt, ist verpflichtend, da die Alpha-ID nicht versions-stabil ist, d.h. Codes können zwischen den unterschiedlichen Jahrensangaben in der Bedeutung wechseln.
 
-**Name**: CodingAlphaID ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingAlphaID&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingAlphaID ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingAlphaID&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingAlphaID`
 

--- a/ig/markdown/Datentypen-Coding-OPS.md
+++ b/ig/markdown/Datentypen-Coding-OPS.md
@@ -5,7 +5,7 @@ Bei der Kodierung per [OPS](https://www.bfarm.de/DE/Kodiersysteme/Klassifikation
 
 Die Angabe der OPS-Version (z.B."2019"), aus der ein Code stammt, ist verpflichtend, da OPS nicht versions-stabil ist, d.h. Codes können zwischen den unterschiedlichen Jahrensangaben in der Bedeutung wechseln.
 
-**Name**: CodingOPS ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingOPS&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingOPS ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingOPS&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingOPS`
 

--- a/ig/markdown/Datentypen-Coding-PZN.md
+++ b/ig/markdown/Datentypen-Coding-PZN.md
@@ -3,7 +3,7 @@
 
 Bei der Kodierung per [PZN](http://www.pruefziffernberechnung.de/Originaldokumente/PZN/pruefzif.pdf) muss das Element Condition.code mit mindestens einem Coding gefüllt sein, das den Anforderungen der PZN-Kodierung genügt. Hierzu sollte beim Einbinden des Coding-Profils in das entsprechende Use-Case-Profil ein Binding auf das PZN ValueSet hinzugefügt werden. Siehe {{pagelink:ig/markdown/Terminologie-ValueSets.md}}.
 
-**Name**: CodingPZN ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingPZN&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingPZN ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingPZN&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingPZN`
 

--- a/ig/markdown/Datentypen-ICD-10GM-Coding.md
+++ b/ig/markdown/Datentypen-ICD-10GM-Coding.md
@@ -5,7 +5,7 @@ Bei der Kodierung per [ICD-10-GM](https://www.bfarm.de/DE/Kodiersysteme/Klassifi
 
 Die Angabe der ICD-Version (z.B."2019"), aus der ein Code stammt, ist verpflichtend, das ICD-GM nicht versions-stabil ist, d.h. Codes können zwischen den unterschiedlichen Jahresangaben in der Bedeutung wechseln.
 
-**Name**: CodingICD10GM ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingICD10GM&scope=de.basisprofil.r4@1.5.4))
+**Name**: CodingICD10GM ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/CodingICD10GM&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/CodingICD10GM`
 

--- a/ig/markdown/EKG.md
+++ b/ig/markdown/EKG.md
@@ -4,7 +4,7 @@ Deutsches Profil zur Abbildung eines Elektrokardiogramms. Dieses Profil erfasst 
 
 #### Profil
 
-**Name**: EkgDE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-ekg&scope=de.basisprofil.r4@1.5.4))
+**Name**: EkgDE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-ekg&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-ekg`
 

--- a/ig/markdown/EinheitlichenFortbildungsnummerEFN-Identifier.md
+++ b/ig/markdown/EinheitlichenFortbildungsnummerEFN-Identifier.md
@@ -2,7 +2,7 @@
 
 Die Abbldung einer Einheitlichen Fortbildungsnummer zur eindeutigen Identifizierung eines persönliches Fortbildungskonto nach § 95d SGB V kann durch folgendes Identifier-Profil erfolgen:
 
-**Name**: IdentifierEfn ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-efn&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierEfn ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-efn&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-efn`
 

--- a/ig/markdown/ExtensionsfrAccount.md
+++ b/ig/markdown/ExtensionsfrAccount.md
@@ -1,7 +1,7 @@
 ### {{page-title}}
 
 
-**Name**: Extension Abrechnungsart ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ExtensionAbrechnungsart@1.5.4))
+**Name**: Extension Abrechnungsart ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ExtensionAbrechnungsart@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/ExtensionAbrechnungsart' select description```
 
@@ -31,7 +31,7 @@
 
 
 **Name**: Extension Fallbezogene Abrechnungsrelevanz von Diagnosen und Prozeduren
-([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ExtensionAbrechnungsDiagnoseProzedur@1.5.4))
+([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ExtensionAbrechnungsDiagnoseProzedur@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/ExtensionAbrechnungsDiagnoseProzedur' select description```
 

--- a/ig/markdown/ExtensionsfrComposition.md
+++ b/ig/markdown/ExtensionsfrComposition.md
@@ -4,7 +4,7 @@ Folgende Extensions werden im Kontext der [FHIR Ressource 'Composition'](https:/
 
 ----
 
-**Name**: ExtensionInformationRecipient ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/informationrecipient&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionInformationRecipient ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/informationrecipient&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/informationrecipient`
 

--- a/ig/markdown/ExtensionsfrCondition.md
+++ b/ig/markdown/ExtensionsfrCondition.md
@@ -6,7 +6,7 @@ Folgende Extensions werden im Kontext der Abbildung einer Kodierung nach [ICD-10
 
 ----
 
-**Name**: Extension-seitenlokalisation ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/seitenlokalisation&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-seitenlokalisation ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/seitenlokalisation&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/seitenlokalisation' select description```
 
@@ -36,7 +36,7 @@ Folgende Extensions werden im Kontext der Abbildung einer Kodierung nach [ICD-10
 
 ----
 
-**Name**: Extension-ICD10GMDiagnosesicherheit ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-ICD10GMDiagnosesicherheit ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit' select description```
 
@@ -64,7 +64,7 @@ Folgende Extensions werden im Kontext der Abbildung einer Kodierung nach [ICD-10
 
 ----
 
-**Name**: Extension-ICD10GMMehrfachcodierungs-Kennzeichen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/icd-10-gm-mehrfachcodierungs-kennzeichen&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-ICD10GMMehrfachcodierungs-Kennzeichen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/icd-10-gm-mehrfachcodierungs-kennzeichen&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/icd-10-gm-mehrfachcodierungs-kennzeichen' select description```
 
@@ -89,7 +89,7 @@ Folgende Extensions werden im Kontext der Abbildung einer Kodierung nach [ICD-10
 
 ### Lebensphase
 
-**Name**: ExtensionLebensphase ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/lebensphase&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionLebensphase ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/lebensphase&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/icd-10-gm-mehrfachcodierungs-kennzeichen' select description```
 

--- a/ig/markdown/ExtensionsfrCoverage.md
+++ b/ig/markdown/ExtensionsfrCoverage.md
@@ -4,7 +4,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvBesonderePersonengruppe ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/besondere-personengruppe&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvBesonderePersonengruppe ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/besondere-personengruppe&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/besondere-personengruppe' select description```
 
@@ -36,7 +36,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvDmpKennzeichen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/dmp-kennzeichen&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvDmpKennzeichen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/dmp-kennzeichen&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/dmp-kennzeichen' select description```
 
@@ -66,7 +66,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvEinlesedatumKarte ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/einlesedatum-karte&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvEinlesedatumKarte ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/einlesedatum-karte&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/einlesedatum-karte' select description```
 
@@ -89,7 +89,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 ----
 
 
-**Name**: Extension-GkvGenerationEg ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/generation-egk&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvGenerationEg ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/generation-egk&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/generation-egk' select description```
 
@@ -111,7 +111,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvKostenerstattung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/kostenerstattung&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvKostenerstattung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/kostenerstattung&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/kostenerstattung' select description```
 
@@ -138,7 +138,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvOnlinepruefungEgk ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/onlinepruefung-egk&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvOnlinepruefungEgk ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/onlinepruefung-egk&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/onlinepruefung-egk' select description```
 
@@ -168,7 +168,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvRuhenderLeistungsanspruch ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/ruhender-leistungsanspruch&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvRuhenderLeistungsanspruch ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/ruhender-leistungsanspruch&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/ruhender-leistungsanspruch' select description```
 
@@ -199,7 +199,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvVersichertenart ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/versichertenart&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvVersichertenart ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/versichertenart&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/versichertenart' select description```
 
@@ -229,7 +229,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvVersionVsdm ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/version-vsdm&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvVersionVsdm ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/version-vsdm&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/version-vsdm' select description```
 
@@ -254,7 +254,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 
 ----
 
-**Name**: Extension-GkvWop ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/wop&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvWop ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/wop&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/wop' select description```
 
@@ -283,7 +283,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
 ```
 ----
 
-**Name**: Extension-GkvZuzahlungsstatus ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/zuzahlungsstatus&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-GkvZuzahlungsstatus ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gkv/zuzahlungsstatus&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gkv/zuzahlungsstatus' select description```
 

--- a/ig/markdown/ExtensionsfrEncounter.md
+++ b/ig/markdown/ExtensionsfrEncounter.md
@@ -4,7 +4,7 @@ Folgende Extensions werden im Kontext der [FHIR Ressource 'Encounter'](https://w
 
 ----
 
-**Name**: ExtensionAufnahmegrund ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Aufnahmegrund&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionAufnahmegrund ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Aufnahmegrund&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/Aufnahmegrund`
 
@@ -45,7 +45,7 @@ Weitere Infos siehe [Datenübermittlung nach § 301 Abs. 3 SGB V](https://www.dk
 
 ----
 
-**Name**: ExtensionEntlassungsgrund ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Entlassungsgrund&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionEntlassungsgrund ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Entlassungsgrund&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/Entlassungsgrund`
 
@@ -79,7 +79,7 @@ Weitere Infos siehe [Datenübermittlung nach § 301 Abs. 3 SGB V](https://www.dk
 
 ----
 
-**Name**: ExtensionWahlleistungen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Wahlleistung&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionWahlleistungen ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/Wahlleistung&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/Wahlleistung`
 

--- a/ig/markdown/ExtensionsfrMedication.md
+++ b/ig/markdown/ExtensionsfrMedication.md
@@ -4,7 +4,7 @@ Folgende Extensions werden im Kontext des [FHIR Medication Modules](https://www.
 
 ----
 
-Name: Extension-normgroesse ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/normgroesse&scope=de.basisprofil.r4@1.5.4))
+Name: Extension-normgroesse ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/normgroesse&scope=de.basisprofil.r4@1.6.0))
 
 Beschreibung: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/normgroesse' select description```
 
@@ -30,7 +30,7 @@ Beispiel:
 
 ----
 
-Name: ExtensionWirkstofftyp ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/WirkstofftypEX&scope=de.basisprofil.r4@1.5.4))
+Name: ExtensionWirkstofftyp ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/WirkstofftypEX&scope=de.basisprofil.r4@1.6.0))
 
 Beschreibung: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/WirkstofftypEX' select description```
 

--- a/ig/markdown/ExtensionsfrPatient.md
+++ b/ig/markdown/ExtensionsfrPatient.md
@@ -6,7 +6,7 @@ Folgende Extensions werden im Kontext des [FHIR Datentyps 'HumanName'](https://w
 
 ----
 
-**Name**: Extension-humanname-namenszusatz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/humanname-namenszusatz&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-humanname-namenszusatz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/humanname-namenszusatz&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/humanname-namenszusatz' select description```
 
@@ -36,7 +36,7 @@ Folgende Extensions werden im Kontext des [FHIR Datentyps 'Addresse'](https://ww
 
 ----
 
-**Name**: Extension-address-ags ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/destatis/ags&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-address-ags ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/destatis/ags&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/destatis/ags' select description```
 
@@ -67,7 +67,7 @@ Folgende Extensions werden im Kontext der Abbildung eines [Administrativen Gesch
 
 ----
 
-**Name**: GenderOtherDE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gender-amtlich-de&scope=de.basisprofil.r4@1.5.4))
+**Name**: GenderOtherDE ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/gender-amtlich-de&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/gender-amtlich-de' select description```
 

--- a/ig/markdown/ExtensionsfrProcedure.md
+++ b/ig/markdown/ExtensionsfrProcedure.md
@@ -4,7 +4,7 @@ Folgende Extensions werden im Kontext der [FHIR Ressource 'Procedure'](https://w
 
 ----
 
-**Name**: ExtensionProzedurDokumentationsdatum ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ProzedurDokumentationsdatum&scope=de.basisprofil.r4@1.5.4))
+**Name**: ExtensionProzedurDokumentationsdatum ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/ProzedurDokumentationsdatum&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/ProzedurDokumentationsdatum`
 
@@ -22,7 +22,7 @@ Folgende Extensions werden im Kontext der [FHIR Ressource 'Procedure'](https://w
 
 ----
 
-**Name**: Extension-seitenlokalisation ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/seitenlokalisation&scope=de.basisprofil.r4@1.5.4))
+**Name**: Extension-seitenlokalisation ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/seitenlokalisation&scope=de.basisprofil.r4@1.6.0))
 
 **Beschreibung**: @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/seitenlokalisation' select description```
 

--- a/ig/markdown/GlasgowComaScale.md
+++ b/ig/markdown/GlasgowComaScale.md
@@ -1,6 +1,6 @@
 #### {{page-title}}
 
-**Name**: VitalSignDE_GCS ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-gcs&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_GCS ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-gcs&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-gcs`
 

--- a/ig/markdown/GradderBehinderung.md
+++ b/ig/markdown/GradderBehinderung.md
@@ -2,7 +2,7 @@
 
 #### Profil
 
-**Name**: GradDerBehinderung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/GradDerBehinderung&scope=de.basisprofil.r4@1.5.4))
+**Name**: GradDerBehinderung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/GradDerBehinderung&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/GradDerBehinderung`
 

--- a/ig/markdown/Home.md
+++ b/ig/markdown/Home.md
@@ -4,7 +4,7 @@
 {{render:Basisprofil-DE-R4/hl7-logo}}
 
 ---
-Version: 1.5.4 ({{pagelink:ig/markdown/ReleaseNotes.md}})
+Version: 1.6.0 ({{pagelink:ig/markdown/ReleaseNotes.md}})
 
 Datum: 16.06.2025
 

--- a/ig/markdown/InstitutionskennzeichenIKNR.md
+++ b/ig/markdown/InstitutionskennzeichenIKNR.md
@@ -2,7 +2,7 @@
 
 Als eindeutiges Merkmal zur Identifizierung von Vertragspartnern, die für die Sozialversicherungsträger Leistungen erbringen wird die IKNR durch die [Arbeitsgemeinschaft Institutionskennzeichen](https://www.dguv.de/arge-ik/index.jsp) vergeben. 
 
-**Name**: IdentifierIknr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-iknr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierIknr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-iknr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-iknr`
 

--- a/ig/markdown/KZVAbrechnungsnummer-Identifier.md
+++ b/ig/markdown/KZVAbrechnungsnummer-Identifier.md
@@ -2,7 +2,7 @@
 
 In Anlehnung einer BSNR kann eine KZVAbrechnungsnummer für die eindeutige Identifizierung von Betriebsstätten, vergeben durch die Kassenzahnärztliche Bundesvereinigung, durch folgendes Identifier-Profil abgebildet werden: 
 
-**Name**: IdentifierKzva ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-kzva&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierKzva ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-kzva&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-kzva`
 

--- a/ig/markdown/LebenslangeArztnummerLANR-Identifier.md
+++ b/ig/markdown/LebenslangeArztnummerLANR-Identifier.md
@@ -5,7 +5,7 @@ Die lebenslange Arztnummer (LANR) ist eine neunstellige Nummer, die die zuständ
 In FHIR kann die LANR als Identifier für Practitioner verwendet werden.
 Das folgende Profil beschreibt die Abbildung einer LANR als Identifier:
 
-**Name**: IdentifierLanr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-lanr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierLanr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-lanr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-lanr`
 

--- a/ig/markdown/LebenslangeBeschaeftigtennummerLBNR-Identifier.md
+++ b/ig/markdown/LebenslangeBeschaeftigtennummerLBNR-Identifier.md
@@ -5,7 +5,7 @@ Im Beschäftigtenverzeichnis der ambulanten Pflege (BeVaP) wird durch das BfArM 
 In FHIR kann die LBNR als Identifier für Practitioner verwendet werden.
 Das folgende Profil beschreibt die Abbildung einer LBNR als Identifier:
 
-**Name**: IdentifierLbnr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-lbnr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierLbnr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-lbnr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-lbnr`
 

--- a/ig/markdown/LebenslangeKrankenversichertennummer10-stelligeKVID-Identifier.md
+++ b/ig/markdown/LebenslangeKrankenversichertennummer10-stelligeKVID-Identifier.md
@@ -1,6 +1,6 @@
 #### Lebenslange Krankenversicherten-ID (10-stellige KVID)
 
-**Name**: IdentifierKvid10 ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-kvid-10&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierKvid10 ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-kvid-10&scope=de.basisprofil.r4@1.6.0))
 
 **Gültigkeit**: Das Profil gilt für alle Krankenversichertennummern, unabhängig, ob es sich um GKV, PKV oder Sonderkostenträger handelt!
 
@@ -48,7 +48,7 @@ Die Angabe von `Identifier.type` ist optional, da die Versichertennummer als sol
 Folgendes Identifier-Profil kann für die Übertragung von pseudonymisierte GKV Krankenversichertennummer verwendet werden:
 
 
-**Name**: IdentifierPseudoKvid ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pseudo-kvid&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierPseudoKvid ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pseudo-kvid&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-pseudo-kvid`
 

--- a/ig/markdown/LebenslangeZahnarztnummerZANR-Identifier.md
+++ b/ig/markdown/LebenslangeZahnarztnummerZANR-Identifier.md
@@ -7,7 +7,7 @@ Die Zahnarztnummer ist 9-stellig numerisch.
 In FHIR kann die ZANR als Identifier für Practitioner verwendet werden.
 Das folgende Profil beschreibt die Abbildung einer ZANR als Identifier:
 
-**Name**: IdentifierZanr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-zanr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierZanr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-zanr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-zanr`
 

--- a/ig/markdown/OrganisationsinternerPatienten-Identifier.md
+++ b/ig/markdown/OrganisationsinternerPatienten-Identifier.md
@@ -1,6 +1,6 @@
 #### Organisationsinterner Patienten-Identifier (PID)
 
-**Name**: IdentifierPid ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pid&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierPid ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pid&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-pid`
 

--- a/ig/markdown/PrivateKrankenversichertennummer-Identifier.md
+++ b/ig/markdown/PrivateKrankenversichertennummer-Identifier.md
@@ -17,7 +17,7 @@ In diesem Fall ist das Element `Identifier.assigner` zu verwenden, um mindestens
 Ohne Angabe einer NamingSystem-URL in `Identifier.system` ist es jedoch nicht möglich, einen [Token-Suchparameter](http://hl7.org/implement/standards/fhir/search.html#token) zu definieren, der zuverlässig eindeutige Ergebnisse liefert.
 Falls dies in einem konkreten Szenario zu Problemen führt, bitten wir um [Feedback im FHIR-Chat](https://chat.fhir.org/#narrow/stream/179183-german-(d-a-ch)/topic/NamingSystem.20f.C3.BCr.20PKV.20Nummern)
 
-**Name**: IdentifierPkv ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pkv&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierPkv ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-pkv&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-pkv`
 

--- a/ig/markdown/Reisepassnummer-Identifier.md
+++ b/ig/markdown/Reisepassnummer-Identifier.md
@@ -2,7 +2,7 @@
 
 Für die Abbildung einer deutschen Reisepassnummer kann folgendes Identifier-Profil verwendet werden:
 
-**Name**: IdentifierReisepassnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-reisepassnummer&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierReisepassnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-reisepassnummer&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-reisepassnummer`
 

--- a/ig/markdown/ReleaseNotes.md
+++ b/ig/markdown/ReleaseNotes.md
@@ -1,5 +1,11 @@
 ### Release Notes
 
+v1.6.0 - tbd
+
+* `changed` VitalSignDE_Koerpertemperatur_SNOMED_CT Die Konzepte: 386725007 "Body temperature (observable entity)" $sct#415922000 "Temperature of forehead (observable entity)" wurden deprecated. Das Konzept: 1366425007 | Estimated core body temperature measured on forehead (observable entity) wurde hinzugefügt.
+* `changed` Umbennung VitalSignDE_Koerpertemperatur_SNOMED_CT nach VitalSignDE_Koerperkerntemperatur_SNOMED_CT
+* `changed` Umbennung VitalSignDE_Koerpertemperatur nach VitalSignDE_Koerperkerntemperatur
+
 v1.5.4 - 16.06.25
 
 * `added` Hinweise zur Handhabung von Organisationskontakt hinzugefügt.

--- a/ig/markdown/Ressourcen-ChargeItem-EBM-Ziffern.md
+++ b/ig/markdown/Ressourcen-ChargeItem-EBM-Ziffern.md
@@ -3,7 +3,7 @@
 
 Das folgende Profil stellt die Dokumentation einer erbrachten Leistung gemäß EBM-Katalog dar:
 
-**Name**: ChargeItemEBM ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/chargeitem-de-ebm&scope=de.basisprofil.r4@1.5.4))
+**Name**: ChargeItemEBM ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/chargeitem-de-ebm&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/chargeitem-de-ebm`
 

--- a/ig/markdown/Ressourcen-Condition-ICD-10-GM.md
+++ b/ig/markdown/Ressourcen-Condition-ICD-10-GM.md
@@ -38,7 +38,7 @@ Folgende Constraints sind für Condition.code zu beachten:
 
 @``` from StructureDefinition where url = 'http://fhir.de/StructureDefinition/CodingICD10GM' for differential.element.constraint select key, severity, human, expression```
 
-Um auf der condition-related Extension auch Suchen zu können wurde wurde der Suchparameter **related** ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/SearchParameter/Condition-related&scope=de.basisprofil.r4@1.5.4)) erstellt.
+Um auf der condition-related Extension auch Suchen zu können wurde wurde der Suchparameter **related** ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/SearchParameter/Condition-related&scope=de.basisprofil.r4@1.6.0)) erstellt.
 
 Um stets alle Codes einer Mehrfachkodierung zu erhalten, empfiehlt es sich ICD-10-GM Diagnosen stets mittels revinclude  
  `GET [base]/Condition?_id=123&_revinclude=Condition:related` abzurufen.

--- a/ig/markdown/Ressourcen-Coverage-Basisprofil.md
+++ b/ig/markdown/Ressourcen-Coverage-Basisprofil.md
@@ -7,7 +7,7 @@ Alle spezialisierten Coverage-Profile sind von diesem Basisprofil abgeleitet.
 
 Für Versicherungsverhältnisse, die kein spezialisiertes Profil haben, sollte das Basisprofil verwendet werden.
 
-**Name**: CoverageDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-basis&scope=de.basisprofil.r4@1.5.4))
+**Name**: CoverageDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-basis&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/coverage-de-basis`
 

--- a/ig/markdown/Ressourcen-Coverage-GKV-Profil.md
+++ b/ig/markdown/Ressourcen-Coverage-GKV-Profil.md
@@ -5,7 +5,7 @@ Für die Abbildung eines gesetzlichen Versicherungsverhältnisses sind die Infor
 
 Das Profil enthält spezielle Extensions, die Informationen über den Einlesevorgang der eKG sowie dem Inhalt des darauf gespeicherten Datensatzes abbilden:
 
-**Name**: CoverageDeGkv ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-gkv&scope=de.basisprofil.r4@1.5.4))
+**Name**: CoverageDeGkv ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-gkv&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/coverage-de-gkv`
 

--- a/ig/markdown/Ressourcen-Coverage-Selbstzahler-Profil.md
+++ b/ig/markdown/Ressourcen-Coverage-Selbstzahler-Profil.md
@@ -5,7 +5,7 @@ Unter den Begriff "Selbstzahler" fallen hier auch Fälle mit abweichendem Rechnu
 
 Für die Abbildung eines Selbstzahler-Verhältnisses sind über das Basisprofil hinaus folgende Mindestangaben erforderlich:
 
-**Name**: CoverageDeSel ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-sel&scope=de.basisprofil.r4@1.5.4))
+**Name**: CoverageDeSel ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/coverage-de-sel&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/coverage-de-sel`
 

--- a/ig/markdown/Ressourcen-Observation-Pflegegrad.md
+++ b/ig/markdown/Ressourcen-Observation-Pflegegrad.md
@@ -5,7 +5,7 @@ Deutsches Profil zur Abbildung des Pflegegrads eines Patienten incl. Abbildung d
 
 #### Profil
 
-**Name**: ObservationDePflegegrad ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-pflegegrad&scope=de.basisprofil.r4@1.5.4))
+**Name**: ObservationDePflegegrad ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-pflegegrad&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-pflegegrad`
 

--- a/ig/markdown/Ressourcen-Observation-VS-PeriphereArtierielleSauerstoffsttigung.md
+++ b/ig/markdown/Ressourcen-Observation-VS-PeriphereArtierielleSauerstoffsttigung.md
@@ -1,6 +1,6 @@
 #### Periphere Artierielle Sauerstoffsättigung
 
-**Name**: VitalSignDE_Periphere_Artierielle_Sauerstoffsaettigung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Periphere_Artierielle_Sauerstoffsaettigung ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Atemfrequenz.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Atemfrequenz.md
@@ -1,6 +1,6 @@
 #### Atemfrequenz
 
-**Name**: VitalSignDE_Atemfrequenz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-atemfrequenz&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Atemfrequenz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-atemfrequenz&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-atemfrequenz`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Blutdruck.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Blutdruck.md
@@ -1,6 +1,6 @@
 #### Blutdruck
 
-**Name**: VitalSignDE_Blutdruck ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-blutdruck&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Blutdruck ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-blutdruck&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-blutdruck`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Herzfrequenz.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Herzfrequenz.md
@@ -1,6 +1,6 @@
 #### Herzfrequenz
 
-**Name**: VitalSignDE_Herzfrequenz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-herzfrequenz&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Herzfrequenz ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-herzfrequenz&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-herzfrequenz`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Koerpergewicht.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Koerpergewicht.md
@@ -1,6 +1,6 @@
 #### Körpergewicht
 
-**Name**: VitalSignDE_Koerpergewicht ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergewicht&scope=de.basisprofil.r4@1.5.4)
+**Name**: VitalSignDE_Koerpergewicht ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergewicht&scope=de.basisprofil.r4@1.6.0)
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergewicht`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-KoerperlaengeKoerpergroese.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-KoerperlaengeKoerpergroese.md
@@ -1,6 +1,6 @@
 #### Körperlänge/Körpergröße
 
-**Name**: VitalSignDE_Koerpergroesse ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergroesse&scope=de.basisprofil.r4@1.5.4)
+**Name**: VitalSignDE_Koerpergroesse ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergroesse&scope=de.basisprofil.r4@1.6.0)
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergroesse`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Koerpertemperatur.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Koerpertemperatur.md
@@ -1,6 +1,6 @@
 #### Körpertemperatur
 
-**Name**: VitalSignDE_Koerpertemperatur ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpertemperatur&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Koerpertemperatur ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpertemperatur&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpertemperatur`
 

--- a/ig/markdown/Ressourcen-Observation-Vitalparameter-Kopfumfang.md
+++ b/ig/markdown/Ressourcen-Observation-Vitalparameter-Kopfumfang.md
@@ -1,6 +1,6 @@
 #### Kopfumfang
 
-**Name**: VitalSignDE_Kopfumfang ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-kopfumfang&scope=de.basisprofil.r4@1.5.4))
+**Name**: VitalSignDE_Kopfumfang ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/observation-de-vitalsign-kopfumfang&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/observation-de-vitalsign-kopfumfang`
 

--- a/ig/markdown/Ressourcen-Patient-Addresse.md
+++ b/ig/markdown/Ressourcen-Patient-Addresse.md
@@ -24,7 +24,7 @@ Dies Address-bezogenen Bestandteilen der Anschrift lassen sich in FHIR wie folgt
 
 #### Basisprofil für Adresse 
 
-**Name**: AddressDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/address-de-basis&scope=de.basisprofil.r4@1.5.4))
+**Name**: AddressDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/address-de-basis&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/address-de-basis`
 

--- a/ig/markdown/Ressourcen-Patient-Name.md
+++ b/ig/markdown/Ressourcen-Patient-Name.md
@@ -15,7 +15,7 @@ Häufig ist dies jedoch nicht erforderlich, da die Standard-Felder `family`, `gi
 
 #### Basis-Profil für Datentyp HumanName
 
-**Name**: HumannameDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/humanname-de-basis&scope=de.basisprofil.r4@1.5.4))
+**Name**: HumannameDeBasis ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/humanname-de-basis&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/humanname-de-basis`
 

--- a/ig/markdown/Standortnummer--DKG.md
+++ b/ig/markdown/Standortnummer--DKG.md
@@ -1,6 +1,6 @@
 #### {{page-title}}
 
-**Name**: IdentifierStandortnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-standortnummer&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierStandortnummer ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-standortnummer&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-standortnummer`
 

--- a/ig/markdown/Telematik-ID.md
+++ b/ig/markdown/Telematik-ID.md
@@ -2,7 +2,7 @@
 
 Zur Abbildung einer [Telematik-ID](https://fachportal.gematik.de/fachportal-import/files/gemSpec_PKI_V2.10.2.pdf) zur eindeutigen Identifizierung der elektronischen Identität von Teilnehmer in der Telematikinfrastruktur kann folgendes Profil verwendet werden:
 
-**Name**: IdentifierTelematikId ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-telematik-id&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierTelematikId ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-telematik-id&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-telematik-id`
 

--- a/ig/markdown/Terminologie-Namensraueme-NationaleNamensraeume.md
+++ b/ig/markdown/Terminologie-Namensraueme-NationaleNamensraeume.md
@@ -4,7 +4,7 @@
 Bei Namensräumen, die einrichtungsübergreifend genutzt werden, und denen eine besondere Bedeutung zukommt, ist es für die Interoperabilität unerlässlich, systemübergreifend eindeutige Symbole zu verwenden.
 Aus diesem Grund definiert dieser Leitfaden URLs für einige häufig verwendete Namensräume, deren Verwendung bei der Implementierung von FHIR verbindlich ist.
 
-Die Spezifikationen der Namensräume deutscher Profile als NamingSystem-Ressourcen müssen konform zum [Basisprofil für NameSpaces](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/namingsystem-de-basis&scope=de.basisprofil.r4@1.5.4) sein.
+Die Spezifikationen der Namensräume deutscher Profile als NamingSystem-Ressourcen müssen konform zum [Basisprofil für NameSpaces](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/namingsystem-de-basis&scope=de.basisprofil.r4@1.6.0) sein.
 
 Für Deutschland sind folgende besondere Namensräume definiert:
 

--- a/ig/markdown/VertragskassennummerVKNR-Identifier.md
+++ b/ig/markdown/VertragskassennummerVKNR-Identifier.md
@@ -2,7 +2,7 @@
 
 Die Vertragskassennummer der Kassenärztlichen Vereinigungen (VKNR) identifiziert Krankenkassen für Abrechnungszwecke. Für eine Abbildung der VKNR kann folgendes Profil verwendet werden:
 
-**Name**: IdentifierVknr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-vknr&scope=de.basisprofil.r4@1.5.4))
+**Name**: IdentifierVknr ([Simplifier Projekt Link](https://simplifier.net/resolve?canonical=http://fhir.de/StructureDefinition/identifier-vknr&scope=de.basisprofil.r4@1.6.0))
 
 **Canonical**: `http://fhir.de/StructureDefinition/identifier-vknr`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "de.basisprofil.r4",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Projekt Basisprofilierung R4 (HL7 Deutschland e.V.)",
   "author": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",
   "fhirVersions": [

--- a/qc/custom.rules.yaml
+++ b/qc/custom.rules.yaml
@@ -5,7 +5,7 @@
   filter: (StructureDefinition or ValueSet or CodeSystem or CapabilityStatement or SearchParameter or ConceptMap).exists()
   # Excluding NamingSystem as they have no version, also exclude ImplementationGuide as metadata cannot be set in Simplifier right now
   status: "Checking if all resources have version filled"
-  predicate: version.exists() and (version in ('1.5.4'))
+  predicate: version.exists() and (version in ('1.6.0'))
   error-message: "version not filled (correctly)"
 
 - action: Check for valid ids

--- a/resources/fsh-generated/resources/CodeSystem-Abrechnungsart.json
+++ b/resources/fsh-generated/resources/CodeSystem-Abrechnungsart.json
@@ -6,7 +6,7 @@
   "id": "Abrechnungsart",
   "title": "Abrechnungsart",
   "description": "Codierung verschiedener in DE üblicher Abrechnungsarten basierend gesetzlichen Grundlagen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/Abrechnungsart",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-Aufnahmeanlass.json
+++ b/resources/fsh-generated/resources/CodeSystem-Aufnahmeanlass.json
@@ -6,7 +6,7 @@
   "id": "Aufnahmeanlass",
   "title": "CodeSystemAufnahmeanlass",
   "description": "Aufnahmeanlass, Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dgkev/Aufnahmeanlass",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-AufnahmegrundDritteStelle.json
+++ b/resources/fsh-generated/resources/CodeSystem-AufnahmegrundDritteStelle.json
@@ -6,7 +6,7 @@
   "id": "AufnahmegrundDritteStelle",
   "title": "AufnahmegrundDritteStelle",
   "description": "Aufnahmegrund (3. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/AufnahmegrundDritteStelle",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-AufnahmegrundErsteUndZweiteStelle.json
+++ b/resources/fsh-generated/resources/CodeSystem-AufnahmegrundErsteUndZweiteStelle.json
@@ -6,7 +6,7 @@
   "id": "AufnahmegrundErsteUndZweiteStelle",
   "title": "CodeSystemAufnahmegrundErsteUndZweiteStelle",
   "description": "Aufnahmegrund (1. und 2. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/AufnahmegrundErsteUndZweiteStelle",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-AufnahmegrundVierteStelle.json
+++ b/resources/fsh-generated/resources/CodeSystem-AufnahmegrundVierteStelle.json
@@ -6,7 +6,7 @@
   "id": "AufnahmegrundVierteStelle",
   "title": "AufnahmegrundVierteStelle",
   "description": "Aufnahmegrund (4. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/AufnahmegrundVierteStelle",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-CodeSystemISO31662DE.json
+++ b/resources/fsh-generated/resources/CodeSystem-CodeSystemISO31662DE.json
@@ -6,7 +6,7 @@
   "id": "CodeSystemISO31662DE",
   "title": "ISO-3166-2:de-Laendercodes",
   "description": "Die Liste der ISO-3166-2:DE Codes für Deutschland enthält die Codes für die deutschen Länder.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "urn:iso:std:iso:3166-2:de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-EntlassungsgrundDritteStelle.json
+++ b/resources/fsh-generated/resources/CodeSystem-EntlassungsgrundDritteStelle.json
@@ -6,7 +6,7 @@
   "id": "EntlassungsgrundDritteStelle",
   "title": "EntlassungsgrundDritteStelle",
   "description": "Entlassungs-/Verlegungsgrund (3. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundDritteStelle",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-EntlassungsgrundErsteUndZweiteStelle.json
+++ b/resources/fsh-generated/resources/CodeSystem-EntlassungsgrundErsteUndZweiteStelle.json
@@ -6,7 +6,7 @@
   "id": "EntlassungsgrundErsteUndZweiteStelle",
   "title": "EntlassungsgrundErsteUndZweiteStelle",
   "description": "Entlassungs-/Verlegungsgrund (1. und 2. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/EntlassungsgrundErsteUndZweiteStelle",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-Fachabteilungsschluessel-erweitert.json
+++ b/resources/fsh-generated/resources/CodeSystem-Fachabteilungsschluessel-erweitert.json
@@ -6,7 +6,7 @@
   "id": "Fachabteilungsschluessel-erweitert",
   "title": "Fachabteilungsschluessel Erweitert",
   "description": "Fachabteilungen gemäß Anhang 1 der BPflV in der am 31.12.2003 geltenden Fassung inkl. Spezialisierungen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel-erweitert",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-Fachabteilungsschluessel.json
+++ b/resources/fsh-generated/resources/CodeSystem-Fachabteilungsschluessel.json
@@ -6,7 +6,7 @@
   "id": "Fachabteilungsschluessel",
   "title": "Fachabteilungsschluessel",
   "description": "Fachabteilungen gemäß Anhang 1 der BPflV in der am 31.12.2003 geltenden Fassung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-KontaktArtDe.json
+++ b/resources/fsh-generated/resources/CodeSystem-KontaktArtDe.json
@@ -6,7 +6,7 @@
   "id": "KontaktArtDe",
   "title": "KontaktArtDe",
   "description": "Klassifizierung eines Kontaktes mit einer Gesundheitseinrichtung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/kontaktart-de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-KontaktDiagnoseProzedur.json
+++ b/resources/fsh-generated/resources/CodeSystem-KontaktDiagnoseProzedur.json
@@ -6,7 +6,7 @@
   "id": "KontaktDiagnoseProzedur",
   "title": "KontaktDiagnoseProzedur",
   "description": "Rolle/Relevanz von Diagnosen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/KontaktDiagnoseProzedur",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-Kontaktebene.json
+++ b/resources/fsh-generated/resources/CodeSystem-Kontaktebene.json
@@ -6,7 +6,7 @@
   "id": "Kontaktebene",
   "title": "Kontaktebene",
   "description": "CodeSystem für die Ebene eines Kontaktes mit einer Gesundheitseinrichtung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/Kontaktebene",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-WirkstofftypCS.json
+++ b/resources/fsh-generated/resources/CodeSystem-WirkstofftypCS.json
@@ -6,7 +6,7 @@
   "id": "WirkstofftypCS",
   "title": "CodeSystem - Wirkstofftypen",
   "description": "Codes zur Differenzierung von Wirkstoffen zwischen genauer Substanz (z.B. Salz, Ester etc.), allgemeiner (normalisierter) Substanz und Kombinationscode für mehrere Wirkstoffe.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/WirkstofftypCS",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-administrative-gender-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-administrative-gender-supplement.json
@@ -6,7 +6,7 @@
   "id": "administrative-gender-supplement",
   "title": "Deutsche Übersetzungen für AdministrativeGender",
   "description": "CodeSystem Supplement mit Deutschen Übersetzungen für AdministrativeGender",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/administrative-gender-supplement",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-cs-common-meta-tag-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-cs-common-meta-tag-de.json
@@ -6,7 +6,7 @@
   "id": "cs-common-meta-tag-de",
   "title": "CS Basisprofil Common Meta Tag DE",
   "description": "Gebräuchliche Codes zur Kodierung von Resource.meta.tag",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/common-meta-tag-de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-cs-merkzeichen-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-cs-merkzeichen-de.json
@@ -6,7 +6,7 @@
   "id": "cs-merkzeichen-de",
   "title": "Deutsche Merkzeichen auf dem Behindertenausweis",
   "description": "Deutsche Merkzeichen, wie sie auf dem Behindertenausweis verwendet werden",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/merkzeichen-de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-diagnosis-role-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-diagnosis-role-supplement.json
@@ -6,7 +6,7 @@
   "id": "diagnosis-role-supplement",
   "title": "Rolle der Diagnose",
   "description": "CodeSystem Supplement mit Deutschen Übersetzungen für Diagnose-Rollen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/diagnosis-role-supplement",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-gender-amtlich-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-gender-amtlich-de.json
@@ -6,7 +6,7 @@
   "id": "gender-amtlich-de",
   "title": "amtliches Geschlecht",
   "description": "Codes zur Erfassung des amtlichen Geschlechts auf Basis der Spezifikationen \"XPersonenstand - Elektronische Datenübermittlung im Personenstandswesen\" und \"Kassenärztliche Vereinigung-Datentransfer\" der KBV",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/gender-amtlich-de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-icd-10-gm-mehrfachcodierungs-kennzeichen.json
+++ b/resources/fsh-generated/resources/CodeSystem-icd-10-gm-mehrfachcodierungs-kennzeichen.json
@@ -6,7 +6,7 @@
   "id": "icd-10-gm-mehrfachcodierungs-kennzeichen",
   "title": "Mehrfachkodierungs-Kennzeichen",
   "description": "Zusatzkennzeichen für postkoordinierte ICD-10-gm-Codes",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/icd-10-gm-mehrfachcodierungs-kennzeichen",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-identifier-type-de-basis.json
+++ b/resources/fsh-generated/resources/CodeSystem-identifier-type-de-basis.json
@@ -6,7 +6,7 @@
   "id": "identifier-type-de-basis",
   "title": "Identifier Type De Basis",
   "description": "Liste der Identfikatorentypen des deutschen Basisprofils welche die Standardtypen ergänzen.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/identifier-type-de-basis",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-identifier-type-v2-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-identifier-type-v2-supplement.json
@@ -6,7 +6,7 @@
   "id": "identifier-type-v2-supplement",
   "title": "Deutsche Übersetzungen für Identifier Types (V2)",
   "description": "CodeSystem Supplement mit Deutschen Übersetzungen für Identifier Types (V2)",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/identifier-type-v2-supplement",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-klassifikation.json
+++ b/resources/fsh-generated/resources/CodeSystem-klassifikation.json
@@ -6,7 +6,7 @@
   "id": "klassifikation",
   "title": "ARGE IK Klassifikation",
   "description": "Klassifikationen und deren Geltungsbereiche, Regionalschlüssel, Seriennummern-Kontingente und Vergabestellen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/arge-ik/klassifikation",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-marital-status-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-marital-status-supplement.json
@@ -6,7 +6,7 @@
   "id": "marital-status-supplement",
   "title": "Deutsche Übersetzungen für MaritalStatus",
   "description": "CodeSystem Supplement mit Deutschen Übersetzungen für MaritalStatus",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/marital-status-supplement",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-observation-category-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-observation-category-supplement.json
@@ -6,7 +6,7 @@
   "id": "observation-category-supplement",
   "title": "Deutsche Übersetzungen für ObservationCategoryCodes",
   "description": "CodeSystem Supplement mit Deutschen Übersetzungen für ObservationCategoryCodes",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/observation-category-supplement",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-supplement-iso-3166.json
+++ b/resources/fsh-generated/resources/CodeSystem-supplement-iso-3166.json
@@ -6,7 +6,7 @@
   "id": "supplement-iso-3166",
   "title": "CodeSystem Supplement ISO 3166",
   "description": "Offizieller Name eines Staates in deutscher Sprache ISO-3166, basierend auf der Übersetzung der ISO 3166 Codes durch die Bundesanstalt für Landwirtschaft und Ernährung (https://www.ble.de/SharedDocs/Downloads/EN/Climate-Energy/Information-Nabisy/CountryCodes.pdf?__blob=publicationFile&v=2)",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/supplement-iso-3166",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-versicherungsart-de-basis.json
+++ b/resources/fsh-generated/resources/CodeSystem-versicherungsart-de-basis.json
@@ -6,7 +6,7 @@
   "id": "versicherungsart-de-basis",
   "title": "VersicherungsartDeBasis",
   "description": "Art der Versicherung bzw. des Kostenträgers.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/versicherungsart-de-basis",
   "concept": [
     {

--- a/resources/fsh-generated/resources/CodeSystem-wahlleistungen-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-wahlleistungen-de.json
@@ -6,7 +6,7 @@
   "id": "wahlleistungen-de",
   "title": "Wahlleistungen",
   "description": "Wahlleistungen bzgl. Unterkunft und Ärztliche Wahlleistungen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/CodeSystem/wahlleistungen-de",
   "concept": [
     {

--- a/resources/fsh-generated/resources/ConceptMap-ConceptMap-OPS-SNOMED-Category-Mapping.json
+++ b/resources/fsh-generated/resources/ConceptMap-ConceptMap-OPS-SNOMED-Category-Mapping.json
@@ -3,7 +3,7 @@
   "id": "ConceptMap-OPS-SNOMED-Category-Mapping",
   "url": "http://fhir.de/ConceptMap/OPS-SNOMED-Category",
   "status": "active",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "experimental": false,
   "date": "2025-06-16",
   "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",

--- a/resources/fsh-generated/resources/SearchParameter-Condition-related.json
+++ b/resources/fsh-generated/resources/SearchParameter-Condition-related.json
@@ -3,7 +3,7 @@
   "id": "Condition-related",
   "url": "http://fhir.de/SearchParameter/Condition-related",
   "status": "active",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "experimental": false,
   "date": "2025-06-16",
   "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",

--- a/resources/fsh-generated/resources/StructureDefinition-AbrechnendeIK.json
+++ b/resources/fsh-generated/resources/StructureDefinition-AbrechnendeIK.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "AbrechnendeIK",
   "url": "http://fhir.de/StructureDefinition/AbrechnendeIK",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionAbrechnendeIK",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-Aufnahmegrund.json
+++ b/resources/fsh-generated/resources/StructureDefinition-Aufnahmegrund.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "Aufnahmegrund",
   "url": "http://fhir.de/StructureDefinition/Aufnahmegrund",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionAufnahmegrund",
   "title": "ExtensionAufnahmegrund",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingASK.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingASK.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingASK",
   "url": "http://fhir.de/StructureDefinition/CodingASK",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingASK",
   "title": "Coding-Profil für ASK",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingATC.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingATC.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingATC",
   "url": "http://fhir.de/StructureDefinition/CodingATC",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingATC",
   "title": "Coding-Profil für ATC",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingAlphaID.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingAlphaID.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingAlphaID",
   "url": "http://fhir.de/StructureDefinition/CodingAlphaID",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingAlphaID",
   "title": "Coding-Profil für Alpha-ID",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingAlphaIDSE.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingAlphaIDSE.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingAlphaIDSE",
   "url": "http://fhir.de/StructureDefinition/CodingAlphaIDSE",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingAlphaIDSE",
   "title": "Coding-Profil für Alpha-ID-SE",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingCAS.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingCAS.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingCAS",
   "url": "http://fhir.de/StructureDefinition/CodingCAS",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingCAS",
   "title": "Coding-Profil für CAS",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingICD10GM.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingICD10GM.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingICD10GM",
   "url": "http://fhir.de/StructureDefinition/CodingICD10GM",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingICD10GM",
   "title": "Coding-Profil für ICD-10-GM",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingOPS.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingOPS.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingOPS",
   "url": "http://fhir.de/StructureDefinition/CodingOPS",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingOPS",
   "title": "Coding-Profil für OPS",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-CodingPZN.json
+++ b/resources/fsh-generated/resources/StructureDefinition-CodingPZN.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "CodingPZN",
   "url": "http://fhir.de/StructureDefinition/CodingPZN",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CodingPZN",
   "title": "Coding-Profil für PZN",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-Entlassungsgrund.json
+++ b/resources/fsh-generated/resources/StructureDefinition-Entlassungsgrund.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "Entlassungsgrund",
   "url": "http://fhir.de/StructureDefinition/Entlassungsgrund",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionEntlassungsgrund",
   "title": "ExtensionEntlassungsgrund",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ExtensionAbrechnungsDiagnoseProzedur.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ExtensionAbrechnungsDiagnoseProzedur.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ExtensionAbrechnungsDiagnoseProzedur",
   "url": "http://fhir.de/StructureDefinition/ExtensionAbrechnungsDiagnoseProzedur",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionAbrechnungsDiagnoseProzedur",
   "title": "Fallbezogene Abrechnungsrelevanz von Diagnosen und Prozeduren",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ExtensionAbrechnungsart.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ExtensionAbrechnungsart.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ExtensionAbrechnungsart",
   "url": "http://fhir.de/StructureDefinition/ExtensionAbrechnungsart",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionAbrechnungsart",
   "title": "Abrechnungsart",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ExtensionFachabteilungsschluessel301.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ExtensionFachabteilungsschluessel301.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ExtensionFachabteilungsschluessel301",
   "url": "http://fhir.de/StructureDefinition/dkgev/fachabteilungsschluessel301",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionFachabteilungsschluessel301",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-ExtensionLebensphase.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ExtensionLebensphase.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ExtensionLebensphase",
   "url": "http://fhir.de/StructureDefinition/lebensphase",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionLebensphase",
   "title": "Extension zur Dokumentation einer Lebensphase einer Person in der ein bestimmtes Ereignis aufgetreten ist",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-GradDerBehinderung.json
+++ b/resources/fsh-generated/resources/StructureDefinition-GradDerBehinderung.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "GradDerBehinderung",
   "url": "http://fhir.de/StructureDefinition/GradDerBehinderung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "GradDerBehinderung",
   "title": "Grad der Behinderung",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ProzedurDokumentationsdatum.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ProzedurDokumentationsdatum.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ProzedurDokumentationsdatum",
   "url": "http://fhir.de/StructureDefinition/ProzedurDokumentationsdatum",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionProzedurDokumentationsdatum",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-Wahlleistung.json
+++ b/resources/fsh-generated/resources/StructureDefinition-Wahlleistung.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "Wahlleistung",
   "url": "http://fhir.de/StructureDefinition/Wahlleistung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionWahlleistung",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-WirkstofftypEX.json
+++ b/resources/fsh-generated/resources/StructureDefinition-WirkstofftypEX.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "WirkstofftypEX",
   "url": "http://fhir.de/StructureDefinition/WirkstofftypEX",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "WirkstofftypEX",
   "title": "ExtensionWirkstofftyp",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-address-de-basis.json
+++ b/resources/fsh-generated/resources/StructureDefinition-address-de-basis.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "address-de-basis",
   "url": "http://fhir.de/StructureDefinition/address-de-basis",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "AddressDeBasis",
   "title": "Adresse, deutsches Basisprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ags.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ags.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ags",
   "url": "http://fhir.de/StructureDefinition/destatis/ags",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionDestatisAgs",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-besondere-personengruppe.json
+++ b/resources/fsh-generated/resources/StructureDefinition-besondere-personengruppe.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "besondere-personengruppe",
   "url": "http://fhir.de/StructureDefinition/gkv/besondere-personengruppe",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvBesonderePersonengruppe",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-chargeitem-de-ebm.json
+++ b/resources/fsh-generated/resources/StructureDefinition-chargeitem-de-ebm.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "chargeitem-de-ebm",
   "url": "http://fhir.de/StructureDefinition/chargeitem-de-ebm",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ChargeItemEBM",
   "title": "ChargeItem für EBM-Ziffer als Abrechnungsposition",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-coverage-de-basis.json
+++ b/resources/fsh-generated/resources/StructureDefinition-coverage-de-basis.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "coverage-de-basis",
   "url": "http://fhir.de/StructureDefinition/coverage-de-basis",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CoverageDeBasis",
   "title": "Coverage, deutsches Basisprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-coverage-de-gkv.json
+++ b/resources/fsh-generated/resources/StructureDefinition-coverage-de-gkv.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "coverage-de-gkv",
   "url": "http://fhir.de/StructureDefinition/coverage-de-gkv",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CoverageDeGkv",
   "title": "Coverage, deutsches GKV-Profil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-coverage-de-sel.json
+++ b/resources/fsh-generated/resources/StructureDefinition-coverage-de-sel.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "coverage-de-sel",
   "url": "http://fhir.de/StructureDefinition/coverage-de-sel",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "CoverageDeSel",
   "title": "Coverage, deutsches Selbstzahlerprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-dmp-kennzeichen.json
+++ b/resources/fsh-generated/resources/StructureDefinition-dmp-kennzeichen.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "dmp-kennzeichen",
   "url": "http://fhir.de/StructureDefinition/gkv/dmp-kennzeichen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvDmpKennzeichen",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-einlesedatum-karte.json
+++ b/resources/fsh-generated/resources/StructureDefinition-einlesedatum-karte.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "einlesedatum-karte",
   "url": "http://fhir.de/StructureDefinition/gkv/einlesedatum-karte",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvEinlesedatumKarte",
   "title": "Extension zur Erfassung des Einlesedatums der eGK bzw. KVK",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-gender-amtlich-de.json
+++ b/resources/fsh-generated/resources/StructureDefinition-gender-amtlich-de.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "gender-amtlich-de",
   "url": "http://fhir.de/StructureDefinition/gender-amtlich-de",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "GenderOtherDE",
   "title": "Differenzierung des administrativen Geschlechts 'other'",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-generation-egk.json
+++ b/resources/fsh-generated/resources/StructureDefinition-generation-egk.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "generation-egk",
   "url": "http://fhir.de/StructureDefinition/gkv/generation-egk",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvGenerationEgk",
   "title": "Extension zur Erfassung der Generation der eGK",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-humanname-de-basis.json
+++ b/resources/fsh-generated/resources/StructureDefinition-humanname-de-basis.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "humanname-de-basis",
   "url": "http://fhir.de/StructureDefinition/humanname-de-basis",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "HumannameDeBasis",
   "title": "HumanName, deutsches Basisprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-humanname-namenszusatz.json
+++ b/resources/fsh-generated/resources/StructureDefinition-humanname-namenszusatz.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "humanname-namenszusatz",
   "url": "http://fhir.de/StructureDefinition/humanname-namenszusatz",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "HumannameNamenszusatz",
   "title": "Extension zur Erfassung der VSDM Namensbestandteile",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-icd-10-gm-diagnosesicherheit.json
+++ b/resources/fsh-generated/resources/StructureDefinition-icd-10-gm-diagnosesicherheit.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "icd-10-gm-diagnosesicherheit",
   "url": "http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionICD10GMDiagnosesicherheit",
   "title": "Extension zur Erfassung der Diagnosesicherheit gemäß KBV-Kodierrichtlinien",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-icd-10-gm-mehrfachcodierungs-kennzeichen.json
+++ b/resources/fsh-generated/resources/StructureDefinition-icd-10-gm-mehrfachcodierungs-kennzeichen.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "icd-10-gm-mehrfachcodierungs-kennzeichen",
   "url": "http://fhir.de/StructureDefinition/icd-10-gm-mehrfachcodierungs-kennzeichen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionMehrfachcodierungKennzeichen",
   "title": "Mehrfachkodierungs-Kennzeichen bei  ICD-10-gm",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-abrechnungsnummer.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-abrechnungsnummer.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-abrechnungsnummer",
   "url": "http://fhir.de/StructureDefinition/identifier-abrechnungsnummer",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierAbrechnungsnummer",
   "title": "Identifier-Profil für die Abbildung einer Abrechnungsnummer (\"Fallnummer\")",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-aufnahmenummer.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-aufnahmenummer.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-aufnahmenummer",
   "url": "http://fhir.de/StructureDefinition/identifier-aufnahmenummer",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierAufnahmenummer",
   "title": "Identifier-Profil für die Abbildung einer Aufnahmenummer (\"Bewegungsnummer\", \"Kontaktnummer\")",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-bsnr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-bsnr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-bsnr",
   "url": "http://fhir.de/StructureDefinition/identifier-bsnr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierBsnr",
   "title": "Identifier-Profil für die Abbildung einer Betriebsstättennummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-efn.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-efn.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-efn",
   "url": "http://fhir.de/StructureDefinition/identifier-efn",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierEfn",
   "title": "Identifier-Profil für die Abbildung der Einheitlichen Fortbildungsnummer (EFN)",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-iknr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-iknr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-iknr",
   "url": "http://fhir.de/StructureDefinition/identifier-iknr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierIknr",
   "title": "Identifier-Profil für die Abbildung eines Institutionskennzeichens (IKNR)",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-kvid-10.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-kvid-10.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-kvid-10",
   "url": "http://fhir.de/StructureDefinition/identifier-kvid-10",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierKvid10",
   "title": "Identifier-Profil für die 10-stellige Krankenversichertennummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-kzva.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-kzva.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-kzva",
   "url": "http://fhir.de/StructureDefinition/identifier-kzva",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierKzva",
   "title": "Identifier-Profil für die Abbildung einer KZVAbrechnungsnummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-lanr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-lanr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-lanr",
   "url": "http://fhir.de/StructureDefinition/identifier-lanr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierLanr",
   "title": "Identifier-Profil für die Abbildung einer lebenslangen Arztnummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-lbnr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-lbnr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-lbnr",
   "url": "http://fhir.de/StructureDefinition/identifier-lbnr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierLbnr",
   "title": "Identifier-Profil für die Abbildung einer lebenslangen Beschäftigtennummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-pid.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-pid.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-pid",
   "url": "http://fhir.de/StructureDefinition/identifier-pid",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierPid",
   "title": "Identifier-Profil für die Abbildung einer Patienten-ID",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-pkv-kvid-10.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-pkv-kvid-10.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-pkv-kvid-10",
   "url": "http://fhir.de/StructureDefinition/identifier-pkv-kvid-10",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierPkvVersichertenId10",
   "title": "Identifier-Profil für die 10-stellige Versicherten ID (PKV)",
   "status": "retired",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-pkv.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-pkv.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-pkv",
   "url": "http://fhir.de/StructureDefinition/identifier-pkv",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierPkv",
   "title": "Identifier-Profil für die Abbildung einer Privatversichertennummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-pseudo-kvid.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-pseudo-kvid.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-pseudo-kvid",
   "url": "http://fhir.de/StructureDefinition/identifier-pseudo-kvid",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierPseudoKvid",
   "title": "Identifier-Profil für die pseudonymisierte Krankenversichertennummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-reisepassnummer.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-reisepassnummer.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-reisepassnummer",
   "url": "http://fhir.de/StructureDefinition/identifier-reisepassnummer",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierReisepassnummer",
   "title": "Identifier-Profil für die Abbildung einer Reisepassnummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-standortnummer.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-standortnummer.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-standortnummer",
   "url": "http://fhir.de/StructureDefinition/identifier-standortnummer",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierStandortnummer",
   "title": "Identifier-Profil für die Standortnummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-telematik-id.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-telematik-id.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-telematik-id",
   "url": "http://fhir.de/StructureDefinition/identifier-telematik-id",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierTelematikId",
   "title": "Identifier-Profil für die Telematik-ID",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-vknr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-vknr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-vknr",
   "url": "http://fhir.de/StructureDefinition/identifier-vknr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierVknr",
   "title": "Identifier-Profil für die Abbildung einer Vertragskassennummer (VKNR)",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-identifier-zanr.json
+++ b/resources/fsh-generated/resources/StructureDefinition-identifier-zanr.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "identifier-zanr",
   "url": "http://fhir.de/StructureDefinition/identifier-zanr",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "IdentifierZanr",
   "title": "Identifier-Profil für die Abbildung einer lebenslangen Zahnarztnummer",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-informationrecipient.json
+++ b/resources/fsh-generated/resources/StructureDefinition-informationrecipient.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "informationrecipient",
   "url": "http://fhir.de/StructureDefinition/informationrecipient",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionInformationRecipient",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-kostenerstattung.json
+++ b/resources/fsh-generated/resources/StructureDefinition-kostenerstattung.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "kostenerstattung",
   "url": "http://fhir.de/StructureDefinition/gkv/kostenerstattung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvKostenerstattung",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-namingsystem-de-basis.json
+++ b/resources/fsh-generated/resources/StructureDefinition-namingsystem-de-basis.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "namingsystem-de-basis",
   "url": "http://fhir.de/StructureDefinition/namingsystem-de-basis",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "NamingsystemDeBasis",
   "title": "Namingsystem, deutsches Basisprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-normgroesse.json
+++ b/resources/fsh-generated/resources/StructureDefinition-normgroesse.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "normgroesse",
   "url": "http://fhir.de/StructureDefinition/normgroesse",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionNormgroesseDeBasis",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-ekg.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-ekg.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-ekg",
   "url": "http://fhir.de/StructureDefinition/observation-de-ekg",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "EkgDE",
   "title": "EKG Observation Profil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-pflegegrad.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-pflegegrad.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-pflegegrad",
   "url": "http://fhir.de/StructureDefinition/observation-de-pflegegrad",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ObservationDePflegegrad",
   "title": "Pflegegrad, deutsches Basisprofil",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-score-gcs.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-score-gcs.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-score-gcs",
   "url": "http://fhir.de/StructureDefinition/observation-de-score-gcs",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ScoreDE_GCS",
   "title": "Observation-Profil Glasgow Coma Score",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-atemfrequenz.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-atemfrequenz.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-atemfrequenz",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-atemfrequenz",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Atemfrequenz",
   "title": "Observation-Profil Atemfrequenz",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-blutdruck.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-blutdruck.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-blutdruck",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-blutdruck",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Blutdruck",
   "title": "Observation-Profil Blutdruck",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-herzfrequenz.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-herzfrequenz.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-herzfrequenz",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-herzfrequenz",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Herzfrequenz",
   "title": "Observation-Profil Herzfrequenz",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpergewicht.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpergewicht.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-koerpergewicht",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergewicht",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Koerpergewicht",
   "title": "Observation-Profil Körpergewicht",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpergroesse.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpergroesse.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-koerpergroesse",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergroesse",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Koerpergroesse",
   "title": "Observation-Profil Körpergröße",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpertemperatur.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-koerpertemperatur.json
@@ -2,9 +2,9 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-koerpertemperatur",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpertemperatur",
-  "version": "1.5.4",
-  "name": "VitalSignDE_Koerpertemperatur",
-  "title": "Observation-Profil Körpertemperatur",
+  "version": "1.6.0",
+  "name": "VitalSignDE_Koerperkerntemperatur",
+  "title": "Observation-Profil Körperkerntemperatur",
   "status": "active",
   "experimental": false,
   "date": "2025-06-16",
@@ -19,7 +19,7 @@
       ]
     }
   ],
-  "description": "Observation-Profil Körpertemperatur",
+  "description": "Observation-Profil Körperkerntemperatur",
   "fhirVersion": "4.0.1",
   "kind": "resource",
   "abstract": false,

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-kopfumfang.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-kopfumfang.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-kopfumfang",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-kopfumfang",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Kopfumfang",
   "title": "Observation - VitalSignDE - Kopfumfang",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-sauerstoffsaettigung-pulsoximetrie.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-sauerstoffsaettigung-pulsoximetrie.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-sauerstoffsaettigung-pulsoximetrie",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung-pulsoximetrie",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Arterielle_Sauerstoffsaettigung_Pulsoximetrie",
   "title": "Observation-Profil Arterielle Sauerstoffsaettigung Pulsoximetrie",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-sauerstoffsaettigung.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign-sauerstoffsaettigung.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign-sauerstoffsaettigung",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE_Arterielle_Sauerstoffsaettigung",
   "title": "Observation-Profil Arterielle Sauerstoffsaettigung",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign.json
+++ b/resources/fsh-generated/resources/StructureDefinition-observation-de-vitalsign.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "observation-de-vitalsign",
   "url": "http://fhir.de/StructureDefinition/observation-de-vitalsign",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "VitalSignDE",
   "title": "Observation-Profil VitalSignDE",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-onlinepruefung-egk.json
+++ b/resources/fsh-generated/resources/StructureDefinition-onlinepruefung-egk.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "onlinepruefung-egk",
   "url": "http://fhir.de/StructureDefinition/gkv/onlinepruefung-egk",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvOnlinepruefungEgk",
   "title": "Informationen zur Onlineprüfung und -aktualisierung",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-ruhender-leistungsanspruch.json
+++ b/resources/fsh-generated/resources/StructureDefinition-ruhender-leistungsanspruch.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "ruhender-leistungsanspruch",
   "url": "http://fhir.de/StructureDefinition/gkv/ruhender-leistungsanspruch",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvRuhenderLeistungsanspruch",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-seitenlokalisation.json
+++ b/resources/fsh-generated/resources/StructureDefinition-seitenlokalisation.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "seitenlokalisation",
   "url": "http://fhir.de/StructureDefinition/seitenlokalisation",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionSeitenlokalisation",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/StructureDefinition-versichertenart.json
+++ b/resources/fsh-generated/resources/StructureDefinition-versichertenart.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "versichertenart",
   "url": "http://fhir.de/StructureDefinition/gkv/versichertenart",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvVersichertenart",
   "title": "Versichertenart GKV",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-version-vsdm.json
+++ b/resources/fsh-generated/resources/StructureDefinition-version-vsdm.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "version-vsdm",
   "url": "http://fhir.de/StructureDefinition/gkv/version-vsdm",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvVersionVsdm",
   "title": "Extension zur Erfassung der Version des CDM-Datensatzes auf der eGK",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-wop.json
+++ b/resources/fsh-generated/resources/StructureDefinition-wop.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "wop",
   "url": "http://fhir.de/StructureDefinition/gkv/wop",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvWop",
   "title": "Kennzeichen Wohnortprinzip (WOP)",
   "status": "active",

--- a/resources/fsh-generated/resources/StructureDefinition-zuzahlungsstatus.json
+++ b/resources/fsh-generated/resources/StructureDefinition-zuzahlungsstatus.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "zuzahlungsstatus",
   "url": "http://fhir.de/StructureDefinition/gkv/zuzahlungsstatus",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "name": "ExtensionGkvZuzahlungsstatus",
   "status": "active",
   "experimental": false,

--- a/resources/fsh-generated/resources/ValueSet-AbrechnungsDiagnoseProzedur.json
+++ b/resources/fsh-generated/resources/ValueSet-AbrechnungsDiagnoseProzedur.json
@@ -5,7 +5,7 @@
   "id": "AbrechnungsDiagnoseProzedur",
   "title": "AbrechnungsDiagnoseProzedur ValueSet",
   "description": "Rolle von Diagnosen und Prozeduren im Abrechnungs-Kontext",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/AbrechnungsDiagnoseProzedur",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-AbrechnungsartVS.json
+++ b/resources/fsh-generated/resources/ValueSet-AbrechnungsartVS.json
@@ -5,7 +5,7 @@
   "id": "AbrechnungsartVS",
   "title": "Abrechnungsart ValueSet",
   "description": "Codierung verschiedener in DE üblicher Abrechnungsarten basierend gesetzlichen Grundlagen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/Abrechnungsart",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ArgeIkKlassifikationVS.json
+++ b/resources/fsh-generated/resources/ValueSet-ArgeIkKlassifikationVS.json
@@ -5,7 +5,7 @@
   "id": "ArgeIkKlassifikationVS",
   "title": "ArgeIkKlassifikation ValueSet",
   "description": "Klassifikationen und deren Geltungsbereiche, Regionalschlüssel, Seriennummern-Kontingente und Vergabestellen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/arge-ik/klassifikation",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-AufnahmeanlassVS.json
+++ b/resources/fsh-generated/resources/ValueSet-AufnahmeanlassVS.json
@@ -5,7 +5,7 @@
   "id": "AufnahmeanlassVS",
   "title": "Aufnahmeanlass ValueSet",
   "description": "Aufnahmeanlass, Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dgkev/Aufnahmeanlass",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-AufnahmegrundDritteStelleVS.json
+++ b/resources/fsh-generated/resources/ValueSet-AufnahmegrundDritteStelleVS.json
@@ -5,7 +5,7 @@
   "id": "AufnahmegrundDritteStelleVS",
   "title": "AufnahmegrundDritteStelle ValueSet",
   "description": "Aufnahmegrund (3. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/AufnahmegrundDritteStelle",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-AufnahmegrundErsteUndZweiteStelleVS.json
+++ b/resources/fsh-generated/resources/ValueSet-AufnahmegrundErsteUndZweiteStelleVS.json
@@ -5,7 +5,7 @@
   "id": "AufnahmegrundErsteUndZweiteStelleVS",
   "title": "Aufnahmegrund Erste und Zweite Stelle ValueSet",
   "description": "Aufnahmegrund (1. und 2. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/AufnahmegrundErsteUndZweiteStelle",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-AufnahmegrundVierteStelleVS.json
+++ b/resources/fsh-generated/resources/ValueSet-AufnahmegrundVierteStelleVS.json
@@ -5,7 +5,7 @@
   "id": "AufnahmegrundVierteStelleVS",
   "title": "Aufnahmegrund Vierte Stelle ValueSet",
   "description": "Aufnahmegrund (4. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/AufnahmegrundVierteStelle",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-DiagnoseTyp.json
+++ b/resources/fsh-generated/resources/ValueSet-DiagnoseTyp.json
@@ -5,7 +5,7 @@
   "id": "DiagnoseTyp",
   "title": "DiagnoseTyp ValueSet",
   "description": "DiagnoseTyp ValueSet",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/DiagnoseTyp",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-Diagnosesubtyp.json
+++ b/resources/fsh-generated/resources/ValueSet-Diagnosesubtyp.json
@@ -5,7 +5,7 @@
   "id": "Diagnosesubtyp",
   "title": "Diagnosesubtyp ValueSet",
   "description": "Diagnosesubtyp ValueSet",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/Diagnosesubtyp",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
@@ -5,7 +5,7 @@
   "id": "EkgAbleitungenVS",
   "title": "SNOMED CT codes der EKG Ableitungen",
   "description": "ValueSet mit den SNOMED CT codes der EKG Ableitungen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/EkgAbleitungenVS",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EkgLeads.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgLeads.json
@@ -5,7 +5,7 @@
   "id": "EkgLeads",
   "title": "EKG/ECG leads",
   "description": "EKG/ECG leads",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/EkgLeads",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EncounterClassDE.json
+++ b/resources/fsh-generated/resources/ValueSet-EncounterClassDE.json
@@ -5,7 +5,7 @@
   "id": "EncounterClassDE",
   "title": "EncounterClassDE",
   "description": "Fallarten und Patientenstatus zur Codierung von Encounter.class",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/EncounterClassDE",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EncounterStatusDe.json
+++ b/resources/fsh-generated/resources/ValueSet-EncounterStatusDe.json
@@ -5,7 +5,7 @@
   "id": "EncounterStatusDe",
   "title": "Encounter Status ValueSet",
   "description": "Einschränkung von Encounter Status in Vorbereitung auf Änderungen in FHIR R5",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/EncounterStatusDe",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EntlassungsgrundDritteStelleVS.json
+++ b/resources/fsh-generated/resources/ValueSet-EntlassungsgrundDritteStelleVS.json
@@ -5,7 +5,7 @@
   "id": "EntlassungsgrundDritteStelleVS",
   "title": "Entlassungsgrund Dritte Stelle ValueSet",
   "description": "Entlassungs-/Verlegungsgrund (3. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/EntlassungsgrundDritteStelle",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-EntlassungsgrundErsteUndZweiteStelleVS.json
+++ b/resources/fsh-generated/resources/ValueSet-EntlassungsgrundErsteUndZweiteStelleVS.json
@@ -5,7 +5,7 @@
   "id": "EntlassungsgrundErsteUndZweiteStelleVS",
   "title": "Entlassungsgrund Erste und Zweite Stelle ValueSet",
   "description": "Entlassungs-/Verlegungsgrund (1. und 2. Stelle), Datenübermittlung nach § 301 Abs. 3 SGB V",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/EntlassungsgrundErsteUndZweiteStelle",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-FachabteilungsschluesselErweitert.json
+++ b/resources/fsh-generated/resources/ValueSet-FachabteilungsschluesselErweitert.json
@@ -5,7 +5,7 @@
   "id": "FachabteilungsschluesselErweitert",
   "title": "FachabteilungsschluesselErweitert ValueSet",
   "description": "Fachabteilungen gemäß Anhang 1 der BPflV in der am 31.12.2003 geltenden Fassung inkl. Spezialisierungen",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/Fachabteilungsschluessel-erweitert",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-FachabteilungsschluesselVS.json
+++ b/resources/fsh-generated/resources/ValueSet-FachabteilungsschluesselVS.json
@@ -5,7 +5,7 @@
   "id": "FachabteilungsschluesselVS",
   "title": "Fachabteilungsschlüssel ValueSet",
   "description": "Fachabteilungen gemäß Anhang 1 der BPflV in der am 31.12.2003 geltenden Fassung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/dkgev/Fachabteilungsschluessel",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-UcumVitalsCommonDE.json
+++ b/resources/fsh-generated/resources/ValueSet-UcumVitalsCommonDE.json
@@ -5,7 +5,7 @@
   "id": "UcumVitalsCommonDE",
   "title": "UCUM Vitals Common DE",
   "description": "Alle innerhalb der VitalSign Profile (DE) erlaubten UCUM Einheiten für value[x]",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/UcumVitalsCommonDE",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ValueSet-GenderOtherDE.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSet-GenderOtherDE.json
@@ -5,7 +5,7 @@
   "id": "ValueSet-GenderOtherDE",
   "title": "GenderOtherDE ValueSet",
   "description": "Codes zur Erfassung des amtlichen Geschlechts auf Basis der Spezifikationen \"XPersonenstand - Elektronische Datenübermittlung im Personenstandswesen\" und \"Kassenärztliche Vereinigung-Datentransfer\" der KB",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/gender-other-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ValueSet-OPS-SNOMED-Source-Codes.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSet-OPS-SNOMED-Source-Codes.json
@@ -5,7 +5,7 @@
   "id": "ValueSet-OPS-SNOMED-Source-Codes",
   "title": "ValueSet of OPS Source Codes for the OPS-SNOMED ConceptMap",
   "description": "ValueSet containing all source concepts from the ConceptMap OPS-SNOMED Category Mapping",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/ValueSet-OPS-SNOMED-Source-Codes",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ValueSetISO31662DE.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSetISO31662DE.json
@@ -5,7 +5,7 @@
   "id": "ValueSetISO31662DE",
   "title": "ISO-3166-2:de-Laendercodes",
   "description": "Enthaelt die ISO-3166-2:DE Codes für die deutschen Bundeslaender.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/iso/bundeslaender",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
@@ -5,7 +5,7 @@
   "id": "ValueSetVitalSignDE-Body-Height-Loinc",
   "title": "ValueSetVitalSignDE_Body_Height_Loinc",
   "description": "VitalSignDE_Body_Height_Loinc enthält Codes zur Kodierung der Messung einer Körpergröße (inkl. Größe bei der Geburt)",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE_Body_Height_Loinc",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Atemfrequenz-SNOMED-CT",
   "title": "VitalSignDE_Atemfrequenz_SNOMED_CT",
   "description": "VitalSignDE_Atemfrequenz_SNOMED_CT enthält die erwarteten $sct Codes für Atemfrequenz",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Atemfrequenz-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Body-Length-UCUM",
   "title": "VitalSignDE_Body_Length_UCUM",
   "description": "VitalSignDE_Body_Length_UCUM enthält alle validen Einheiten zur Kodierung einer Körpergröße",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE_Body_Length_UCUM",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Body-Weigth-UCUM",
   "title": "VitalSignDE_Body_Weigth_UCUM",
   "description": "VitalSignDE_Body_Weigth_UCUM enthält alle validen Einheiten zur Kodierung eines Körpergewichtes",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE_Body_Weigth_UCUM",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Herzfrequenz-SNOMED-CT",
   "title": "VitalSignDE_Herzfrequenz_SNOMED_CT",
   "description": "VitalSignDE_Herzfrequenz_SNOMED_CT enthält die erwarteten $sct Codes für Herzfrequenz",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Herzfrequenz-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Koerpergewicht-SNOMED-CT",
   "title": "VitalSignDE_Koerpergewicht_SNOMED_CT",
   "description": "VitalSignDE_Koerpergewicht_SNOMED_CT enthält die erwarteten $sct Codes für Koerpergewicht",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Koerpergewicht-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Koerpergroesse-SNOMED-CT",
   "title": "VitalSignDE_Koerpergroesse_SNOMED_CT",
   "description": "VitalSignDE_Koerpergroesse_SNOMED_CT enthält die erwarteten $sct Codes für Koerpergroesse",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Koerpergroesse-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
@@ -1,11 +1,11 @@
 {
   "resourceType": "ValueSet",
   "status": "active",
-  "name": "VitalSignDE_Koerpertemperatur_SNOMED_CT",
+  "name": "VitalSignDE_Koerperkerntemperatur_SNOMED_CT",
   "id": "VitalSignDE-Koerpertemperatur-SNOMED-CT",
-  "title": "VitalSignDE_Koerpertemperatur_SNOMED_CT",
-  "description": "VitalSignDE_Koerpertemperatur_SNOMED_CT enthält die erwarteten $sct Codes für Koerpertemperatur",
-  "version": "1.5.4",
+  "title": "VitalSignDE_Koerperkerntemperatur_SNOMED_CT",
+  "description": "VitalSignDE_Koerperkerntemperatur_SNOMED_CT enthält die erwarteten $sct Codes für die Körperkerntemperatur",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Koerpertemperatur-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",
@@ -30,36 +30,52 @@
     "include": [
       {
         "system": "http://snomed.info/sct",
-        "filter": [
+        "concept": [
           {
-            "property": "concept",
-            "op": "is-a",
-            "value": "276885007"
+            "code": "415882003",
+            "display": "Estimated core body temperature measured in axillary region (observable entity)"
+          },
+          {
+            "code": "415929009",
+            "display": "Estimated core body temperature measured in inguinal region (observable entity)"
+          },
+          {
+            "code": "415945006",
+            "display": "Körperkerntemperatur gemessen im sublingualen Raum"
+          },
+          {
+            "code": "1366425007",
+            "display": "Estimated core body temperature measured on forehead (observable entity)"
+          },
+          {
+            "code": "415922000",
+            "display": "Temperature of forehead (observable entity)",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/valueset-deprecated",
+                "valueBoolean": true
+              }
+            ]
+          },
+          {
+            "code": "386725007",
+            "display": "Body temperature (observable entity)",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/valueset-deprecated",
+                "valueBoolean": true
+              }
+            ]
           }
         ]
       },
       {
         "system": "http://snomed.info/sct",
-        "concept": [
+        "filter": [
           {
-            "code": "415882003",
-            "display": "Axillary temperature"
-          },
-          {
-            "code": "415929009",
-            "display": "Groin temperature"
-          },
-          {
-            "code": "415945006",
-            "display": "Orale Temperatur"
-          },
-          {
-            "code": "415922000",
-            "display": "Temperature of forehead (observable entity)"
-          },
-          {
-            "code": "386725007",
-            "display": "Body temperature (observable entity)"
+            "property": "concept",
+            "op": "is-a",
+            "value": "276885007"
           }
         ]
       }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Kopfumfang-SNOMED-CT",
   "title": "VitalSignDE_Kopfumfang_SNOMED_CT",
   "description": "VitalSignDE_Kopfumfang_SNOMED_CT enthält die erwarteten $sct Codes für Kopfumfang",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Kopfumfang-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
@@ -5,7 +5,7 @@
   "id": "VitalSignDE-Sauerstoffsaettigung-SNOMED-CT",
   "title": "VitalSignDE_Sauerstoffsaettigung_SNOMED_CT",
   "description": "VitalSignDE_SauerstoffCsaettigung_SNOMED_CT enthält die erwarteten $sct Codes für Sauerstoffsaettigung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/VitalSignDE-Sauerstoffsaettigung-SNOMED-CT",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-WirkstofftypVS.json
+++ b/resources/fsh-generated/resources/ValueSet-WirkstofftypVS.json
@@ -5,7 +5,7 @@
   "id": "WirkstofftypVS",
   "title": "ValueSet  - Wirkstofftypen",
   "description": "Codes zur Differenzierung von Wirkstoffen zwischen genauer Substanz (z.B. Salz, Ester etc.), allgemeiner (normalisierter) Substanz und Kombinationscode für mehrere Wirkstoffe.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/WirkstofftypVS",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-common-meta-tag-de.json
+++ b/resources/fsh-generated/resources/ValueSet-common-meta-tag-de.json
@@ -4,7 +4,7 @@
   "name": "VS_CommonMetaTag_De",
   "id": "common-meta-tag-de",
   "description": "Gebräuchliche Codes zur Kodierung von Resource.meta.tag",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/common-meta-tag-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
@@ -3,7 +3,7 @@
   "id": "glasgow-coma-score-eye",
   "url": "http://fhir.de/ValueSet/glasgow-coma-score-eye",
   "status": "active",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "experimental": false,
   "date": "2025-06-16",
   "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
@@ -3,7 +3,7 @@
   "id": "glasgow-coma-score-motor",
   "url": "http://fhir.de/ValueSet/glasgow-coma-score-motor",
   "status": "active",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "experimental": false,
   "date": "2025-06-16",
   "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
@@ -3,7 +3,7 @@
   "id": "glasgow-coma-score-verbal",
   "url": "http://fhir.de/ValueSet/glasgow-coma-score-verbal",
   "status": "active",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "experimental": false,
   "date": "2025-06-16",
   "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",

--- a/resources/fsh-generated/resources/ValueSet-icd-10-gm-mehrfachcodierungs-kennzeichen.json
+++ b/resources/fsh-generated/resources/ValueSet-icd-10-gm-mehrfachcodierungs-kennzeichen.json
@@ -5,7 +5,7 @@
   "id": "icd-10-gm-mehrfachcodierungs-kennzeichen",
   "title": "Mehrfachkodierungs-Kennzeichen ICD10GM ValueSet",
   "description": "Zusatzkennzeichen für postkoordinierte ICD-10-gm-Codes ",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/icd-10-gm-mehrfachcodierungs-kennzeichen",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-identifier-type-de-basis.json
+++ b/resources/fsh-generated/resources/ValueSet-identifier-type-de-basis.json
@@ -5,7 +5,7 @@
   "id": "identifier-type-de-basis",
   "title": "Identifier Type DeBasis ValueSet",
   "description": "ValueSet zur Codierung des Identifier-Typs",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/identifier-type-de-basis",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-kontaktart-de.json
+++ b/resources/fsh-generated/resources/ValueSet-kontaktart-de.json
@@ -5,7 +5,7 @@
   "id": "kontaktart-de",
   "title": "KontaktartDe ValueSet",
   "description": "Kontaktarten für die Codierung von Encounter.type",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/kontaktart-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-kontaktebene-de.json
+++ b/resources/fsh-generated/resources/ValueSet-kontaktebene-de.json
@@ -5,7 +5,7 @@
   "id": "kontaktebene-de",
   "title": "KontaktebeneDe ValueSet",
   "description": "Kontaktebene für die Codierung von Encounter.type",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/kontaktebene-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-lebensphase-de.json
+++ b/resources/fsh-generated/resources/ValueSet-lebensphase-de.json
@@ -5,7 +5,7 @@
   "id": "lebensphase-de",
   "title": "LebensphaseDe ValueSet",
   "description": "Dieses Valueset enthält Snomedcodes zur Angabe der Lebensphase",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/lebensphase-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-merkzeichen-de.json
+++ b/resources/fsh-generated/resources/ValueSet-merkzeichen-de.json
@@ -5,7 +5,7 @@
   "id": "merkzeichen-de",
   "title": "Deutsche Merkzeichen auf dem Behindertenausweis",
   "description": "Deutsche Merkzeichen, wie sie auf dem Behindertenausweis verwendet werden",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/merkzeichen-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-ops-vs.json
+++ b/resources/fsh-generated/resources/ValueSet-ops-vs.json
@@ -5,7 +5,7 @@
   "id": "ops-vs",
   "title": "OPS ValueSet",
   "description": "OPS ValueSet",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/bfarm/ops",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-pflegegrad-de.json
+++ b/resources/fsh-generated/resources/ValueSet-pflegegrad-de.json
@@ -5,7 +5,7 @@
   "id": "pflegegrad-de",
   "title": "PflegegradDE ValueSet",
   "description": "Codes zur genaueren Differenzierung des Pflegegrads.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/pflegegrad-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-ICD-10-GM.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-ICD-10-GM.json
@@ -5,7 +5,7 @@
   "id": "valueset-ICD-10-GM",
   "title": "ICD10GM ValueSet",
   "description": "ICD-10-GM",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/bfarm/icd-10-gm",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-VersicherungsartDeBasis.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-VersicherungsartDeBasis.json
@@ -4,7 +4,7 @@
   "name": "VersicherungsartDeBasisVS",
   "id": "valueset-VersicherungsartDeBasis",
   "description": "ValueSet für die in Deutschland üblichen Versicherungsarten",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/versicherungsart-de-basis",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-alpha-id.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-alpha-id.json
@@ -5,7 +5,7 @@
   "id": "valueset-alpha-id",
   "title": "AlphaId ValueSet",
   "description": "Die Alpha-ID ermöglicht es, medizinische und alltagssprachliche Diagnosenbezeichnungen zu kodieren, stellt also Diagnosenkodes zur Verfügung. 2005 als Prototyp vom DIMDI herausgegeben basiert die Alpha-ID auf dem Alphabetischen Verzeichnis zur ICD-10-GM. Jedem Eintrag des Alphabets ist eine fortlaufende, stabile, nichtsprechende Identifikationsnummer zugeordnet: der Alpha-ID-Kode. Er identifiziert den Eintrag eindeutig und übernimmt somit die Funktion eines nichtklassifizierenden Diagnosenkodes.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/bfarm/alpha-id",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-ask.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-ask.json
@@ -5,7 +5,7 @@
   "id": "valueset-ask",
   "title": "ASK ValueSet",
   "description": "Arzneimittel-Stoffkatalog (ASK) Nummern",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/ask",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-atc.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-atc.json
@@ -5,7 +5,7 @@
   "id": "valueset-atc",
   "title": "ATC ValueSet",
   "description": "Anatomisch-therapeutisch-chemische Klassifkation (ATC) mit Tagesdosen deutsche Fassung",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/bfarm/atc",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-pzn.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-pzn.json
@@ -5,7 +5,7 @@
   "id": "valueset-pzn",
   "title": "PZN ValueSet",
   "description": "Die Pharmazentralnummer (PZN) ist ein in Deutschland bundeseinheitlicher Identifikationsschlüssel für Arzneimittel, Hilfsmittel und andere Apothekenprodukte. Sie ist eine achtstellige Nummer (7 Ziffern + Prüfziffer) mit vorangestelltem Minus-Zeichen, die Arzneimittel nach Bezeichnung, Darreichungsform, Wirkstoffstärke und Packungsgröße eindeutig kennzeichnet. Sie wird im Klartext (Zahlen) mit vorangestelltem „PZN“ und als Strichcode (Code39) auf jede Arzneimittelpackung aufgedruckt, wobei die Zeichenfolge „PZN“ nicht im Strichcode enthalten ist.",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/ifa/pzn",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
@@ -5,7 +5,7 @@
   "id": "valueset-wg14",
   "title": "WG14 ValueSet",
   "description": "ABDATA WG14 (aut-idem-Auswahlgruppen, 'ABDA-KBV-Gruppen') für Medikamente",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/abdata/wg14",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-wahlleistungen-de.json
+++ b/resources/fsh-generated/resources/ValueSet-wahlleistungen-de.json
@@ -5,7 +5,7 @@
   "id": "wahlleistungen-de",
   "title": "Deutsche Merkzeichen auf dem Behindertenausweis",
   "description": "Deutsche Merkzeichen, wie sie auf dem Behindertenausweis verwendet werden",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "url": "http://fhir.de/ValueSet/wahlleistungen-de",
   "experimental": false,
   "date": "2025-06-16",

--- a/resources/input/fsh/aliases.fsh
+++ b/resources/input/fsh/aliases.fsh
@@ -49,3 +49,4 @@ Alias: $KBV_VS_SFHIR_KBV_NORMGROESSE = https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR
 Alias: $KBV_VS_SFHIR_ICD_SEITENLOKALISATION = https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_ICD_SEITENLOKALISATION
 Alias: $diagnosis-role = http://terminology.hl7.org/CodeSystem/diagnosis-role
 Alias: $structuredefinition-standards-status = http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+Alias: $valueset-deprecated = http://hl7.org/fhir/StructureDefinition/valueset-deprecated

--- a/resources/input/fsh/profiles/VitalSignDE_Koerpertemperatur.fsh
+++ b/resources/input/fsh/profiles/VitalSignDE_Koerpertemperatur.fsh
@@ -1,20 +1,20 @@
-Profile: VitalSignDE_Koerpertemperatur
+Profile: VitalSignDE_Koerperkerntemperatur
 Parent: VitalSignDE
 Id: observation-de-vitalsign-koerpertemperatur
-Title: "Observation-Profil Körpertemperatur"
-Description: "Observation-Profil Körpertemperatur"
+Title: "Observation-Profil Körperkerntemperatur"
+Description: "Observation-Profil Körperkerntemperatur"
 * insert Meta
 * code
   * insert VitalSignDESlicingWithLoinc
   * coding contains
       snomed 0..*
   * coding[loinc] = $loinc#8310-5
-  * coding[snomed] from VitalSignDE_Koerpertemperatur_SNOMED_CT
+  * coding[snomed] from VitalSignDE_Koerperkerntemperatur_SNOMED_CT
     * ^patternCoding.system = $sct
 * valueQuantity = $unitsofmeasure#Cel
 
 Instance: Example-observation-koerpertemperatur
-InstanceOf: VitalSignDE_Koerpertemperatur
+InstanceOf: VitalSignDE_Koerperkerntemperatur
 Usage: #example
 * meta.profile[+] = "http://hl7.org/fhir/StructureDefinition/vitalsigns"
 * meta.profile[+] = "http://hl7.org/fhir/StructureDefinition/bodytemp"

--- a/resources/input/fsh/rulesets.fsh
+++ b/resources/input/fsh/rulesets.fsh
@@ -1,4 +1,4 @@
-Alias: $version = 1.5.4
+Alias: $version = 1.6.0
 
 RuleSet: MetaNoVersion
 * ^status = #active

--- a/resources/input/fsh/valuesets/VitalSignDE_SnomedCT_ValueSets.fsh
+++ b/resources/input/fsh/valuesets/VitalSignDE_SnomedCT_ValueSets.fsh
@@ -36,19 +36,22 @@ Description: "VitalSignDE_Koerpergroesse_SNOMED_CT enthält die erwarteten $sct 
 * ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
 * include codes from system SNOMED_CT where concept is-a #1153637007 // Körpergröße
 
-ValueSet: VitalSignDE_Koerpertemperatur_SNOMED_CT
+ValueSet: VitalSignDE_Koerperkerntemperatur_SNOMED_CT
 Id: VitalSignDE-Koerpertemperatur-SNOMED-CT
-Title: "VitalSignDE_Koerpertemperatur_SNOMED_CT"
-Description: "VitalSignDE_Koerpertemperatur_SNOMED_CT enthält die erwarteten $sct Codes für Koerpertemperatur"
+Title: "VitalSignDE_Koerperkerntemperatur_SNOMED_CT"
+Description: "VitalSignDE_Koerperkerntemperatur_SNOMED_CT enthält die erwarteten $sct Codes für die Körperkerntemperatur"
 * insert Meta
 * insert SnomedDisclaimer
 * ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
-* include codes from system SNOMED_CT where concept is-a #276885007
-* $sct#415882003 "Axillary temperature"
-* $sct#415929009 "Groin temperature"
-* $sct#415945006 "Orale Temperatur"
+* $sct#415882003 "Estimated core body temperature measured in axillary region (observable entity)"
+* $sct#415929009 "Estimated core body temperature measured in inguinal region (observable entity)"
+* $sct#415945006 "Körperkerntemperatur gemessen im sublingualen Raum"
+* $sct#1366425007 "Estimated core body temperature measured on forehead (observable entity)"
 * $sct#415922000 "Temperature of forehead (observable entity)" // delete in future release (no core temperature)
+  * ^extension[$valueset-deprecated].valueBoolean = true
 * $sct#386725007 "Body temperature (observable entity)" // delete in future release (no core temperature)
+  * ^extension[$valueset-deprecated].valueBoolean = true
+* include codes from system SNOMED_CT where concept is-a #276885007
 
 ValueSet: VitalSignDE_Kopfumfang_SNOMED_CT
 Id: VitalSignDE-Kopfumfang-SNOMED-CT


### PR DESCRIPTION
* `changed` VitalSignDE_Koerpertemperatur_SNOMED_CT Die Konzepte: 386725007 "Body temperature (observable entity)" $sct#415922000 "Temperature of forehead (observable entity)" wurden deprecated. Das Konzept: 1366425007 | Estimated core body temperature measured on forehead (observable entity) wurde hinzugefügt.
* `changed` Umbennung VitalSignDE_Koerpertemperatur_SNOMED_CT nach VitalSignDE_Koerperkerntemperatur_SNOMED_CT
* `changed` Umbennung VitalSignDE_Koerpertemperatur nach VitalSignDE_Koerperkerntemperatur Update version to 1.6.0 across all relevant files
This pull request updates the project to version 1.6.0 and ensures that all references to profiles, extensions, and coding systems in the documentation point to the new version. The changes are mostly updates to version numbers in Simplifier project links across multiple markdown files, ensuring consistency and correctness in documentation and external references.

Version update:

* Updated the `version` field from `1.5.4` to `1.6.0` in `ig/ImplementationGuide.json` to reflect the new release version.

Documentation updates for profile references:

* Updated all Simplifier project links in markdown files (e.g., `Abrechnungsnummer.md`, `Aufnahmenummer.md`, `BetriebsstttennummerBSNR-Identifier.md`, etc.) to reference version `1.6.0` instead of `1.5.4` for associated profiles and identifiers. [[1]](diffhunk://#diff-356267afd7bc750ab5a47e0cd871343b1cdbdd92bccfe481476e5f73f2244108L3-R3) [[2]](diffhunk://#diff-356267afd7bc750ab5a47e0cd871343b1cdbdd92bccfe481476e5f73f2244108L31-R31) [[3]](diffhunk://#diff-727273069d0ff60288826334d41e521dea2eb29cf570555585ab8182ca96a574L3-R3) [[4]](diffhunk://#diff-727273069d0ff60288826334d41e521dea2eb29cf570555585ab8182ca96a574L31-R31) [[5]](diffhunk://#diff-dde1a48d99e4ce5156bf6c961ca31d31dcec4b03c9953bec8b21e80c057b954dL5-R5) [[6]](diffhunk://#diff-322c6f77cc6bd6e020a5cea9c1c36fdb849687ef8359db281fccf85d108cb575L5-R5)

Documentation updates for coding system references:

* Updated Simplifier project links for coding profiles (e.g., `CodingASK`, `CodingATC`, `CodingAlphaIDSE`, `CodingAlphaID`, `CodingOPS`, `CodingPZN`, `CodingICD10GM`, `EkgDE`) in their respective markdown files to reference version `1.6.0`. [[1]](diffhunk://#diff-5e2888e3db8c4414f2aa05ae8fe8c96e82283cb41ff62f4d75fd04b8a4bb9478L6-R6) [[2]](diffhunk://#diff-e36407311b2a6863c0b4dcb5072fd5f3803679f126632e7561d675d1500ca7e1L6-R6) [[3]](diffhunk://#diff-89509d1821fd35061900445c92d68617d668b65d1e8e3276ab59554edcd604adL8-R8) [[4]](diffhunk://#diff-8ab394c7c1ec5c31142ebaa7008e2cd3b23f383b2ef5ab3b2afbe5eebf64b810L8-R8) [[5]](diffhunk://#diff-daa36c6d6913c6d9e5a4acaaf0b91875fb90b8b28ea07653d79fe0a6e97e3caeL8-R8) [[6]](diffhunk://#diff-72fc09165e82edb187bde4cf87efa82c55cb72bfba712e811c0fc46c3590a74aL6-R6) [[7]](diffhunk://#diff-9a7a169a8667ce12fe1138d8192e17a55096e1aeb96cb4503737e16a11982002L8-R8) [[8]](diffhunk://#diff-3b806721d5c938c9e5b20646f42f5787b642edffac18c762918a82c33f55b4d4L7-R7)

Documentation updates for extension references:

* Updated all Simplifier project links for extensions in markdown files (e.g., `ExtensionAbrechnungsart`, `ExtensionAbrechnungsDiagnoseProzedur`, `ExtensionInformationRecipient`, `Extension-seitenlokalisation`, `Extension-ICD10GMDiagnosesicherheit`, `Extension-ICD10GMMehrfachcodierungs-Kennzeichen`, `ExtensionLebensphase`, `Extension-GkvBesonderePersonengruppe`, `Extension-GkvDmpKennzeichen`, `Extension-GkvEinlesedatumKarte`) to reference version `1.6.0`. [[1]](diffhunk://#diff-15e352934d97a6c719f7d5eee11411fba68f413973335756d1afa7c0b896849aL4-R4) [[2]](diffhunk://#diff-15e352934d97a6c719f7d5eee11411fba68f413973335756d1afa7c0b896849aL34-R34) [[3]](diffhunk://#diff-82497b55fa0a634f52f825b634270ee45227ce3f566a9d9984e530e1a40ce365L7-R7) [[4]](diffhunk://#diff-32e419a4185ad14af215428ee50f74176ef67884587c2318b213f33a451a15ecL9-R9) [[5]](diffhunk://#diff-32e419a4185ad14af215428ee50f74176ef67884587c2318b213f33a451a15ecL39-R39) [[6]](diffhunk://#diff-32e419a4185ad14af215428ee50f74176ef67884587c2318b213f33a451a15ecL67-R67) [[7]](diffhunk://#diff-32e419a4185ad14af215428ee50f74176ef67884587c2318b213f33a451a15ecL92-R92) [[8]](diffhunk://#diff-149a9a9b925ce28d97dfce4cf191f7518c7d978bac4683146197a58e76091947L7-R7) [[9]](diffhunk://#diff-149a9a9b925ce28d97dfce4cf191f7518c7d978bac4683146197a58e76091947L39-R39) [[10]](diffhunk://#diff-149a9a9b925ce28d97dfce4cf191f7518c7d978bac4683146197a58e76091947L69-R69)