### PR TITLE
Anpassung Art des ruhenden Leistungsanspruchs

### DIFF
--- a/ig/markdown/ExtensionsfrCoverage.md
+++ b/ig/markdown/ExtensionsfrCoverage.md
@@ -187,6 +187,7 @@ Folgende Extensions sind notwendig um Informationen der elektronische Gesundheit
     <extension url="art">
         <valueCoding>
             <code value="1" />
+            <system value="http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV" />
         </valueCoding>
     </extension>
     <extension url="dauer">

--- a/resources/fsh-generated/resources/CodeSystem-RuhenderLeistungsanspruchGKV.json
+++ b/resources/fsh-generated/resources/CodeSystem-RuhenderLeistungsanspruchGKV.json
@@ -1,0 +1,46 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "active",
+  "content": "complete",
+  "name": "CodeSystemRuhenderLeistungsanspruchGKV",
+  "id": "RuhenderLeistungsanspruchGKV",
+  "title": "Ruhender Leistungsanspruch (GKV)",
+  "description": "Art des ruhenden Leistungsanspruchs für GKV-Versicherte",
+  "version": "1.6.0",
+  "url": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV",
+  "concept": [
+    {
+      "code": "1",
+      "display": "vollständig",
+      "definition": "Der Leistungsanspruch ruht vollständig aufgrund eines der in § 16 SGB V angegebenen Grunds, der nicht auf Abs. 3a (ausstehende Beitragszahlung) zurückzuführen ist."
+    },
+    {
+      "code": "2",
+      "display": "eingeschränkt",
+      "definition": "Der Leistungsanspruch ruht eingeschränkt gemäß § 16 Abs. 3a SGB V, da der Versicherte seiner Verpflichtung zur Beitragszahlung nicht nachkommt."
+    }
+  ],
+  "experimental": false,
+  "date": "2025-06-16",
+  "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.de/technische-komitees/fhir/"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablecodesystem"
+    ]
+  },
+  "caseSensitive": true,
+  "valueSet": "http://fhir.de/ValueSet/gkv/RuhenderLeistungsanspruchGKV",
+  "compositional": false,
+  "purpose": "Das Ruhen des Leistungsanspruchs im Bereich der GKV wird durch § 16 SGB V geregelt. \nNach § 19 Abs. 3 BMV-Ä ist der Leistungsanspruch von Versicherten, die ihrer Verpflichtung zur Beitragszahlung nicht nachkommen, eingeschränkt (§ 16 Abs. 3a SGB V). \nDie verbleibenden Absätze des § 16 SGB V legen die Rahmenbedingungen für ein vollständiges Ruhen des Leistungsanspruchs fest.\nDie von diesem CodeSystem definierten Werte wurden durch die gematik zur Einführung von VSDM 1 im Jahr 2011 festgelegt und werden hier für die Verwendung in FHIR-Profilen zugänglich gemacht.",
+  "count": 2
+}

--- a/resources/fsh-generated/resources/Coverage-Example-coverage-example.json
+++ b/resources/fsh-generated/resources/Coverage-Example-coverage-example.json
@@ -86,7 +86,8 @@
         {
           "url": "art",
           "valueCoding": {
-            "code": "1"
+            "code": "1",
+            "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV"
           }
         },
         {

--- a/resources/fsh-generated/resources/ValueSet-RuhenderLeistungsanspruchGKV.json
+++ b/resources/fsh-generated/resources/ValueSet-RuhenderLeistungsanspruchGKV.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "ValueSetRuhenderLeistungsanspruchGKV",
+  "id": "RuhenderLeistungsanspruchGKV",
+  "title": "Ruhender Leistungsanspruch (GKV)",
+  "description": "Art des ruhenden Leistungsanspruchs für GKV-Versicherte",
+  "version": "1.6.0",
+  "url": "http://fhir.de/ValueSet/gkv/RuhenderLeistungsanspruchGKV",
+  "experimental": false,
+  "date": "2025-06-16",
+  "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.de/technische-komitees/fhir/"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "compose": {
+    "include": [
+      {
+        "system": "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV"
+      }
+    ]
+  }
+}

--- a/resources/input/fsh/codesystems/CodeSystemRuhenderLeistungsanspruchGKV.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemRuhenderLeistungsanspruchGKV.fsh
@@ -1,0 +1,27 @@
+CodeSystem: CodeSystemRuhenderLeistungsanspruchGKV
+Id: RuhenderLeistungsanspruchGKV
+Title: "Ruhender Leistungsanspruch (GKV)"
+Description: "Art des ruhenden Leistungsanspruchs für GKV-Versicherte"
+* insert Meta
+* ^meta.profile = $shareablecodesystem
+* ^url = "http://fhir.de/CodeSystem/gkv/RuhenderLeistungsanspruchGKV" 
+* ^caseSensitive = true
+* ^valueSet = "http://fhir.de/ValueSet/gkv/RuhenderLeistungsanspruchGKV"
+* ^compositional = false
+* ^content = #complete
+* ^purpose = """
+    Das Ruhen des Leistungsanspruchs im Bereich der GKV wird durch § 16 SGB V geregelt. 
+    Nach § 19 Abs. 3 BMV-Ä ist der Leistungsanspruch von Versicherten, die ihrer Verpflichtung zur Beitragszahlung nicht nachkommen, eingeschränkt (§ 16 Abs. 3a SGB V). 
+    Die verbleibenden Absätze des § 16 SGB V legen die Rahmenbedingungen für ein vollständiges Ruhen des Leistungsanspruchs fest.
+    Die von diesem CodeSystem definierten Werte wurden durch die gematik zur Einführung von VSDM 1 im Jahr 2011 festgelegt und werden hier für die Verwendung in FHIR-Profilen zugänglich gemacht.
+  """
+
+* #1 "vollständig"
+  * ^definition = """
+      Der Leistungsanspruch ruht vollständig aufgrund eines der in § 16 SGB V angegebenen Grunds, der nicht auf Abs. 3a (ausstehende Beitragszahlung) zurückzuführen ist.
+    """
+
+* #2 "eingeschränkt"
+  * ^definition = """
+      Der Leistungsanspruch ruht eingeschränkt gemäß § 16 Abs. 3a SGB V, da der Versicherte seiner Verpflichtung zur Beitragszahlung nicht nachkommt.
+    """

--- a/resources/input/fsh/extensions/ExtensionGkvRuhenderLeistungsanspruch.fsh
+++ b/resources/input/fsh/extensions/ExtensionGkvRuhenderLeistungsanspruch.fsh
@@ -14,9 +14,16 @@ Description: "Gibt Art und Dauer des ruhenden Leistungsanspruchs des Versicherte
     dauer 1..1
 * extension[art] ^short = "Gibt die Art des ruhenden Leistungsanspruchs an."
   * ^definition = "Gibt die Art des ruhenden Leistungsanspruchs an."
+  * ^comment = """
+      Das CodeSystem zur Definition der Werte wurde nachträglich eingefügt. 
+      Die Werte sind identisch zu den bereits durch die Invariante ruhend-1 erwzungenen Werten.
+      Es ist daher ausreichend, das CodeSystem zu ergänzen, um die Werte vollständig zu qualifizieren; eine weiter Anpassung ist nicht erforderlich.
+      Um für eine Übergangszeit bestehende Ressourcen nicht zu invalidieren, wird das ValueSet zunächst als preferred binding hinterlegt.
+    """
   * value[x] only Coding
     * code 1..
       * obeys ruhend-1
+  * value[x] from ValueSetRuhenderLeistungsanspruchGKV (preferred)
 * extension[dauer].value[x] only Period
   * start 1..
     * ^short = "Beginn des ruhenden Leistungsanspruchs"

--- a/resources/input/fsh/profiles/CoverageDeGkv.fsh
+++ b/resources/input/fsh/profiles/CoverageDeGkv.fsh
@@ -84,7 +84,7 @@ Usage: #example
 * extension[+].url = "http://fhir.de/StructureDefinition/gkv/besondere-personengruppe"
 * extension[=].valueCoding = $74_CS_SFHIR_KBV_PERSONENGRUPPE#06 "BVG (Gesetz über die Versorgung der Opfer des Krieges)"
 * extension[+].extension[+].url = "art"
-* extension[=].extension[=].valueCoding.code = #1
+* extension[=].extension[=].valueCoding = CodeSystemRuhenderLeistungsanspruchGKV#1
 * extension[=].extension[+].url = "dauer"
 * extension[=].extension[=].valuePeriod.start = "2018-01-01"
 * extension[=].url = "http://fhir.de/StructureDefinition/gkv/ruhender-leistungsanspruch"

--- a/resources/input/fsh/valuesets/ValueSetRuhenderLeistungsanspruchGKV.fsh
+++ b/resources/input/fsh/valuesets/ValueSetRuhenderLeistungsanspruchGKV.fsh
@@ -1,0 +1,8 @@
+ValueSet: ValueSetRuhenderLeistungsanspruchGKV
+Id: RuhenderLeistungsanspruchGKV
+Title: "Ruhender Leistungsanspruch (GKV)"
+Description: "Art des ruhenden Leistungsanspruchs für GKV-Versicherte"
+* insert Meta
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^url = "http://fhir.de/ValueSet/gkv/RuhenderLeistungsanspruchGKV"
+* include codes from system CodeSystemRuhenderLeistungsanspruchGKV


### PR DESCRIPTION
Einführung von CodeSystem und ValueSet für Art des Ruhens mit Dokumentation des gesetzlichen Hintergrunds und der Herkunft der Werte; Hinterlegung als preferred binding (nicht required, um bestehende Ressourcen nicht zu invalidieren)
fixes #661 