### PR TITLE
CodeSystem und ValueSet für PKV-Versichertenart

### DIFF
--- a/resources/fsh-generated/resources/CodeSystem-VersichertenartPKV.json
+++ b/resources/fsh-generated/resources/CodeSystem-VersichertenartPKV.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "active",
+  "content": "complete",
+  "name": "CodeSystemVersichertenartPKV",
+  "id": "VersichertenartPKV",
+  "title": "Versichertenart (PKV)",
+  "description": "Versichertenart von PKV-Versicherten",
+  "version": "1.6.0",
+  "url": "http://fhir.de/CodeSystem/pkv/Versichertenart",
+  "concept": [
+    {
+      "code": "VN",
+      "display": "Versicherungsnehmer",
+      "definition": "Die behandelte Person ist selbst der Versicherungsnehmer."
+    },
+    {
+      "code": "VP",
+      "display": "versicherte Person",
+      "definition": "Die behandelte Person ist nicht selbst der Versicherungsnehmer."
+    }
+  ],
+  "experimental": false,
+  "date": "2025-06-16",
+  "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.de/technische-komitees/fhir/"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablecodesystem"
+    ]
+  },
+  "caseSensitive": true,
+  "valueSet": "http://fhir.de/ValueSet/pkv/Versichertenart",
+  "compositional": false,
+  "count": 2
+}

--- a/resources/fsh-generated/resources/ValueSet-VersichertenartPKV.json
+++ b/resources/fsh-generated/resources/ValueSet-VersichertenartPKV.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "ValueSetVersichertenartPKV",
+  "id": "VersichertenartPKV",
+  "title": "Versichertenart (PKV)",
+  "description": "Versichertenart von PKV-Versicherten",
+  "version": "1.6.0",
+  "url": "http://fhir.de/ValueSet/pkv/Versichertenart",
+  "experimental": false,
+  "date": "2025-06-16",
+  "publisher": "HL7 Deutschland e.V. (Technisches Komitee FHIR)",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.de/technische-komitees/fhir/"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "compose": {
+    "include": [
+      {
+        "system": "http://fhir.de/CodeSystem/pkv/Versichertenart"
+      }
+    ]
+  }
+}

--- a/resources/input/fsh/codesystems/CodeSystemVersichertenartPKV.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemVersichertenartPKV.fsh
@@ -1,0 +1,21 @@
+CodeSystem: CodeSystemVersichertenartPKV
+Id: VersichertenartPKV
+Title: "Versichertenart (PKV)"
+Description: "Versichertenart von PKV-Versicherten"
+* insert Meta
+* ^meta.profile = $shareablecodesystem
+* ^url = "http://fhir.de/CodeSystem/pkv/Versichertenart"
+* ^caseSensitive = true
+* ^valueSet = "http://fhir.de/ValueSet/pkv/Versichertenart"
+* ^compositional = false
+* ^content = #complete
+
+* #VN "Versicherungsnehmer"
+  * ^definition = """
+      Die behandelte Person ist selbst der Versicherungsnehmer.
+    """
+
+* #VP "versicherte Person"
+  * ^definition = """
+      Die behandelte Person ist nicht selbst der Versicherungsnehmer.
+    """

--- a/resources/input/fsh/valuesets/ValueSetVersichertenartPKV.fsh
+++ b/resources/input/fsh/valuesets/ValueSetVersichertenartPKV.fsh
@@ -1,0 +1,8 @@
+ValueSet: ValueSetVersichertenartPKV
+Id: VersichertenartPKV
+Title: "Versichertenart (PKV)"
+Description: "Versichertenart von PKV-Versicherten"
+* insert Meta
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^url = "http://fhir.de/ValueSet/pkv/Versichertenart"
+* include codes from system CodeSystemVersichertenartPKV


### PR DESCRIPTION
Aufnahme eines neuen CodeSystem und ValueSet für die PKV-Versichertenart nach Rücksprache mit dem PKV-Verband. 
fixes #663