### PR TITLE
Hdb 809

### DIFF
--- a/resources/fsh-generated/resources/CodeSystem-CodeSystemISO31662DE.json
+++ b/resources/fsh-generated/resources/CodeSystem-CodeSystemISO31662DE.json
@@ -87,6 +87,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Organization for Standardization (ISO)"
+      }
+    }
+  ],
   "meta": {
     "profile": [
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"

--- a/resources/fsh-generated/resources/CodeSystem-anlage-6-vorsatzworte.json
+++ b/resources/fsh-generated/resources/CodeSystem-anlage-6-vorsatzworte.json
@@ -771,6 +771,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "GKV-Spitzenverband"
+      }
+    }
+  ],
   "meta": {
     "profile": [
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"

--- a/resources/fsh-generated/resources/CodeSystem-anlage-7-namenszusaetze.json
+++ b/resources/fsh-generated/resources/CodeSystem-anlage-7-namenszusaetze.json
@@ -303,6 +303,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "GKV-Spitzenverband"
+      }
+    }
+  ],
   "meta": {
     "profile": [
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"

--- a/resources/fsh-generated/resources/CodeSystem-anlage-8-laenderkennzeichen.json
+++ b/resources/fsh-generated/resources/CodeSystem-anlage-8-laenderkennzeichen.json
@@ -1218,6 +1218,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "GKV-Spitzenverband"
+      }
+    }
+  ],
   "copyright": "GKV-Spitzenverband",
   "caseSensitive": true,
   "property": [

--- a/resources/fsh-generated/resources/CodeSystem-wg14.json
+++ b/resources/fsh-generated/resources/CodeSystem-wg14.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH"
+      }
+    }
+  ],
   "copyright": "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH",
   "caseSensitive": true
 }

--- a/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "compose": {
     "include": [

--- a/resources/fsh-generated/resources/ValueSet-EkgLeads.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgLeads.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the LOINC Committee"
+      }
+    }
+  ],
   "copyright": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.",
   "compose": {
     "include": [

--- a/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
@@ -1,10 +1,10 @@
 {
   "resourceType": "ValueSet",
   "status": "active",
-  "name": "ValueSetVitalSignDE_Body_Height_Loinc",
+  "name": "ValueSetVitalSignDE_Body_Height_Additional_Loinc",
   "id": "ValueSetVitalSignDE-Body-Height-Loinc",
   "title": "ValueSetVitalSignDE_Body_Height_Loinc",
-  "description": "Dieses ValueSet enthält LOINC-Codes zur Kodierung von Körpergrößenmessungen einschließlich der Körpergröße bei Geburt. Es dient der standardisierten Kennzeichnung entsprechender Vitalparameter-Beobachtungen.",
+  "description": "Dieses ValueSet enthält LOINC-Codes zur zusätzlichen Spezifizierung von Körpergrößenmessungen, insbesondere zur Kennzeichnung der Körpergröße bei Geburt. Die Codes dienen als ergänzende Kodierung neben dem verpflichtenden LOINC-Hauptcode des jeweiligen Vital Signs Profils.",
   "version": "1.6.0-ballot",
   "url": "http://fhir.de/ValueSet/VitalSignDE_Body_Height_Loinc",
   "experimental": false,
@@ -18,6 +18,14 @@
           "value": "http://hl7.de/technische-komitees/fhir/"
         }
       ]
+    }
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the LOINC Committee"
+      }
     }
   ],
   "copyright": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.",

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization"
+      }
+    }
+  ],
   "copyright": "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization"
+      }
+    }
+  ],
   "copyright": "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "International Health Terminology Standards Development Organisation (IHTSDO)"
+      }
+    }
+  ],
   "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "meta": {
     "profile": [

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
@@ -17,6 +17,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the LOINC Committee"
+      }
+    }
+  ],
   "name": "VS_Score_GlasgowComaScore_Eye",
   "title": "VS Score Glasgow Coma Score Eye",
   "description": "Dieses ValueSet enthält die Codes für die Augenöffnungs-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung dieses Teilaspekts der neurologischen Beurteilung.",

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
@@ -17,6 +17,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the LOINC Committee"
+      }
+    }
+  ],
   "name": "VS_Score_GlasgowComaScore_Motor",
   "title": "VS Score Glasgow Coma Score Motor",
   "description": "Dieses ValueSet enthält die Codes für die motorische Reaktions-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der motorischen Antwort.",

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
@@ -17,6 +17,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Regenstrief Institute, Inc. and the LOINC Committee"
+      }
+    }
+  ],
   "name": "VS_Score_GlasgowComaScore_Verbal",
   "title": "VS Score Glasgow Coma Score Verbal",
   "description": "Dieses ValueSet enthält die Codes für die verbale Kommunikations-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der verbalen Reaktion.",

--- a/resources/fsh-generated/resources/ValueSet-lebensphase-de.json
+++ b/resources/fsh-generated/resources/ValueSet-lebensphase-de.json
@@ -20,6 +20,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "Kassenärztliche Bundesvereinigung (KBV)"
+      }
+    }
+  ],
   "copyright": "Kassenärztliche Bundesvereinigung (KBV)  \nThis value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "compose": {
     "include": [

--- a/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
@@ -25,6 +25,14 @@
       ]
     }
   ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "name": "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH"
+      }
+    }
+  ],
   "copyright": "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH",
   "compose": {
     "include": [

--- a/resources/input/fsh/codesystems/CodeSystemISO31662DE.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemISO31662DE.fsh
@@ -3,6 +3,7 @@ Id: CodeSystemISO31662DE
 Title: "ISO-3166-2:de-Laendercodes"
 Description: "Dieses CodeSystem enthält die ISO-3166-2:DE-Codes der deutschen Bundesländer. Es dient der standardisierten Kennzeichnung der Bundesländer im deutschen Kontext."
 * insert Meta
+* insert ArtifactAuthor([[International Organization for Standardization (ISO)]])
 * ^meta.profile = $shareablecodesystem
 * ^url = "urn:iso:std:iso:3166-2:de"
 * ^copyright = "International Organization for Standardization"

--- a/resources/input/fsh/codesystems/DeuevAnlage6Vorsatzworte.fsh
+++ b/resources/input/fsh/codesystems/DeuevAnlage6Vorsatzworte.fsh
@@ -3,6 +3,7 @@ Id: anlage-6-vorsatzworte
 Title: "Tabelle der gültigen Vorsatzworte"
 Description: "Dieses CodeSystem enthält die nach DEÜV Anlage 6 zulässigen Vorsatzworte in Nachnamen. Es dient der normgerechten Erfassung und Übermittlung strukturierter Namensbestandteile."
 * insert Meta
+* insert ArtifactAuthor([[GKV-Spitzenverband]])
 * ^meta.profile = $shareablecodesystem
 * ^url = "http://fhir.de/CodeSystem/deuev/anlage-6-vorsatzworte"
 * ^version = "2.30"

--- a/resources/input/fsh/codesystems/DeuevAnlage7Namenszusaetze.fsh
+++ b/resources/input/fsh/codesystems/DeuevAnlage7Namenszusaetze.fsh
@@ -3,6 +3,7 @@ Id: anlage-7-namenszusaetze
 Title: "Tabelle der gültigen Namenszusätze"
 Description: "Dieses CodeSystem enthält die nach DEÜV Anlage 7 zulässigen Namenszusätze. Es dient der standardisierten Erfassung und Übermittlung besonderer namensrechtlicher Bestandteile."
 * insert Meta
+* insert ArtifactAuthor([[GKV-Spitzenverband]])
 * ^meta.profile = $shareablecodesystem
 * ^url = "http://fhir.de/CodeSystem/deuev/anlage-7-namenszusaetze"
 * ^version = "2.25"

--- a/resources/input/fsh/codesystems/DeuevAnlage8Laenderkennzeichen.fsh
+++ b/resources/input/fsh/codesystems/DeuevAnlage8Laenderkennzeichen.fsh
@@ -11,6 +11,7 @@ Description: "Staatsangehörigkeit und Länderkennzeichen für Auslandsanschrift
 * ^publisher = "HL7 Deutschland e.V. (Technisches Komitee FHIR)"
 * ^contact.telecom.system = #url
 * ^contact.telecom.value = "http://hl7.de/technische-komitees/fhir/"
+* insert ArtifactAuthor([[GKV-Spitzenverband]])
 * ^copyright = "GKV-Spitzenverband"
 * ^caseSensitive = true
 * ^content = #complete

--- a/resources/input/fsh/codesystems/WG14.fsh
+++ b/resources/input/fsh/codesystems/WG14.fsh
@@ -5,6 +5,7 @@ Description: "Deprecated - Dieses  CodeSystem steht als technischer Platzhalter 
 * insert MetaNoVersion
 * ^status = #retired
 * ^url = "http://fhir.de/CodeSystem/abdata/wg14"
+* insert ArtifactAuthor([[ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH]])
 * ^copyright = "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH"
 * ^caseSensitive = true
 * ^content = #not-present

--- a/resources/input/fsh/rulesets.fsh
+++ b/resources/input/fsh/rulesets.fsh
@@ -21,13 +21,24 @@ RuleSet: Meta-Instance
 * contact.telecom.system = #url
 * contact.telecom.value = "http://hl7.de/technische-komitees/fhir/"
 
+RuleSet: ArtifactAuthor(name)
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/artifact-author"
+* ^extension[=].valueContactDetail.name = "{name}"
+
+RuleSet: ArtifactAuthorInstance(name)
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/artifact-author"
+* extension[=].valueContactDetail.name = "{name}"
+
 RuleSet: SnomedDisclaimer
+* insert ArtifactAuthor([[International Health Terminology Standards Development Organisation (IHTSDO)]])
 * ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement."
 
 RuleSet: UCUMDisclaimer
+* insert ArtifactAuthor([[Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization]])
 * ^copyright = "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved."
 
 RuleSet: LOINCDisclaimer
+* insert ArtifactAuthor([[Regenstrief Institute, Inc. and the LOINC Committee]])
 * ^copyright = "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
 
 RuleSet: VitalSignDESlicingWithLoinc

--- a/resources/input/fsh/valuesets/ScoreDE_GCS.fsh
+++ b/resources/input/fsh/valuesets/ScoreDE_GCS.fsh
@@ -2,6 +2,7 @@ Instance: glasgow-coma-score-eye
 InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
+* insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
 * name = "VS_Score_GlasgowComaScore_Eye"
 * title = "VS Score Glasgow Coma Score Eye"
 * description = "Dieses ValueSet enthält die Codes für die Augenöffnungs-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung dieses Teilaspekts der neurologischen Beurteilung."
@@ -27,6 +28,7 @@ Instance: glasgow-coma-score-verbal
 InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
+* insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
 * name = "VS_Score_GlasgowComaScore_Verbal"
 * title = "VS Score Glasgow Coma Score Verbal"
 * description = "Dieses ValueSet enthält die Codes für die verbale Kommunikations-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der verbalen Reaktion."
@@ -56,6 +58,7 @@ Instance: glasgow-coma-score-motor
 InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
+* insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
 * name = "VS_Score_GlasgowComaScore_Motor"
 * title = "VS Score Glasgow Coma Score Motor"
 * description = "Dieses ValueSet enthält die Codes für die motorische Reaktions-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der motorischen Antwort."

--- a/resources/input/fsh/valuesets/ValueSetLebensphaseDe.fsh
+++ b/resources/input/fsh/valuesets/ValueSetLebensphaseDe.fsh
@@ -3,6 +3,7 @@ Id: lebensphase-de
 Title: "LebensphaseDe ValueSet"
 Description: "Dieses ValueSet enthält SNOMED-CT-Konzepte zur Angabe von Lebensphasen. Es dient der semantisch präzisen Beschreibung alters- und entwicklungsbezogener Kontexte."
 * insert Meta
+* insert ArtifactAuthor([[Kassenärztliche Bundesvereinigung (KBV)]])
 * ^copyright = """Kassenärztliche Bundesvereinigung (KBV)  
 This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement."""
 * SNOMED_CT#41847000 "Adulthood (qualifier value)"

--- a/resources/input/fsh/valuesets/ValueSetVitalSignDE_Body_Height_Loinc.fsh
+++ b/resources/input/fsh/valuesets/ValueSetVitalSignDE_Body_Height_Loinc.fsh
@@ -1,7 +1,7 @@
-ValueSet: ValueSetVitalSignDE_Body_Height_Loinc
+ValueSet: ValueSetVitalSignDE_Body_Height_Additional_Loinc
 Id: ValueSetVitalSignDE-Body-Height-Loinc
 Title: "ValueSetVitalSignDE_Body_Height_Loinc"
-Description: "Dieses ValueSet enthält LOINC-Codes zur Kodierung von Körpergrößenmessungen einschließlich der Körpergröße bei Geburt. Es dient der standardisierten Kennzeichnung entsprechender Vitalparameter-Beobachtungen."
+Description: "Dieses ValueSet enthält LOINC-Codes zur zusätzlichen Spezifizierung von Körpergrößenmessungen, insbesondere zur Kennzeichnung der Körpergröße bei Geburt. Die Codes dienen als ergänzende Kodierung neben dem verpflichtenden LOINC-Hauptcode des jeweiligen Vital Signs Profils."
 * insert Meta
 * insert LOINCDisclaimer
 * ^url = "http://fhir.de/ValueSet/VitalSignDE_Body_Height_Loinc"

--- a/resources/input/fsh/valuesets/WG14.fsh
+++ b/resources/input/fsh/valuesets/WG14.fsh
@@ -6,5 +6,6 @@ Description: "Deprecated - Dieses  ValueSet referenziert die ehemalige ABDATA-WG
 * insert Meta
 * ^status = #retired
 * ^url = "http://fhir.de/ValueSet/abdata/wg14"
+* insert ArtifactAuthor([[ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH]])
 * ^copyright = "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH"
 * include codes from system WG14


### PR DESCRIPTION
This pull request enhances the FHIR resource JSON files by systematically adding explicit author information to various `CodeSystem` and `ValueSet` resources. Additionally, it updates the name and description of the `ValueSetVitalSignDE-Body-Height-Loinc` resource to clarify its purpose. These changes improve traceability, attribution, and clarity of the resources.

**Enhancements to resource metadata:**

* Added an `extension` field with the `artifact-author` URL to multiple `CodeSystem` and `ValueSet` JSON files, specifying the responsible organization or committee for each resource. This ensures clear attribution for standards and terminologies used. [[1]](diffhunk://#diff-104283da2d037f41b8d068a81a8fa9356740492ee5331d5ceb819bdaff36c5f2R90-R97) [[2]](diffhunk://#diff-c16c9a29fde0546842c14167e64c06f435b5ab573d334af5b0c920384d957cdaR774-R781) [[3]](diffhunk://#diff-3294faf6ed9310e5024bfe352d52528c4aad17d42ae19d42547ca76f30fd69e4R306-R313) [[4]](diffhunk://#diff-7c104894ce09a907792d1a9acf6916455ff7ba124f9b233340ea80bf651dced4R1221-R1228) [[5]](diffhunk://#diff-59a680e62bc71780c85b7273ff979673279443532b52863a0f18a136a6becd73R23-R30) [[6]](diffhunk://#diff-00f81dbbb35f5df9022c0dd7bd95bcc027eda9c697fffb0385fc3dc7603d20a8R23-R30) [[7]](diffhunk://#diff-497ab6397040d5b3185dd26d29ff38b8f4f3a791fdfd9d3175f3baca8988ae4fR23-R30) [[8]](diffhunk://#diff-d0508e7ea7d10e1a1ee113461f7da3b483c727e20fae768b5c3c249285f165c0R23-R30) [[9]](diffhunk://#diff-ed3f82dc5115765b85ee881ea6ddf58ed3b354be636b9a0ee7f8af467672d365R23-R30) [[10]](diffhunk://#diff-fed3467f80465a45b4ec0a43ed822cfeeea2f63921c9a7812524ae79a25576edR23-R30) [[11]](diffhunk://#diff-a811bd247815f6a4ec6e2b57936a575f7cd7386935bab4c86e92c8141a3f8e0cR23-R30) [[12]](diffhunk://#diff-b0fd3c98e8c905d478fe68e4cae7980aecb360d65e4105adacf0375e8ccb174cR23-R30) [[13]](diffhunk://#diff-8efaf974482d558575f5c398d656205c0f1d94765152a6ecd75798171669d2e1R23-R30) [[14]](diffhunk://#diff-2644d3ea11d7c8f5799add337051e78971c46c218c3b54c7b2b92962969cd3aeR23-R30) [[15]](diffhunk://#diff-36ba4e5b4d84c7ee50464fbeb2e1286e090096d0685673400a7d51b297b4769fR23-R30) [[16]](diffhunk://#diff-6eace35312949810730449064675ed89c2606db84f6b8f6c4d0a0483c139ccf9R23-R30) [[17]](diffhunk://#diff-569086e9bb595d00e2ca33595862a104f5532244f90cc76d1b1505875c8a1b84R23-R30) [[18]](diffhunk://#diff-4c2d53a24c39f644b6bba2541f571a8b5c07f16fbef2876d6917467f857d400aR20-R27) [[19]](diffhunk://#diff-34c9113efae08d5c80ad26a65044d448e46d6fcf4f4ffa36c9aca646723f2ac9R20-R27) [[20]](diffhunk://#diff-5c83a555bc72082845e742dec1240cb72f81fe81a3bb0374a8806764fe264f91R20-R27)

**Resource clarification and naming:**

* Renamed the `name` field in `ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json` to `ValueSetVitalSignDE_Body_Height_Additional_Loinc` and updated its `description` to clarify that the codes are for additional specification of body height measurements, especially at birth, and are intended as supplementary to the main LOINC code.

These changes collectively improve the quality, attribution, and clarity of the FHIR resource definitions in the codebase.