### PR TITLE
Add copyright information to various CS&VS

### DIFF
--- a/resources/fsh-generated/resources/CodeSystem-KontaktArtDe.json
+++ b/resources/fsh-generated/resources/CodeSystem-KontaktArtDe.json
@@ -92,5 +92,6 @@
   "valueSet": "http://fhir.de/ValueSet/kontaktart-de",
   "hierarchyMeaning": "is-a",
   "compositional": false,
+  "copyright": "HL7 Deutschland e.V.",
   "count": 12
 }

--- a/resources/fsh-generated/resources/CodeSystem-KontaktDiagnoseProzedur.json
+++ b/resources/fsh-generated/resources/CodeSystem-KontaktDiagnoseProzedur.json
@@ -74,7 +74,7 @@
     ]
   },
   "caseSensitive": false,
-  "copyright": "HL7 Deutschland e.V.",
+  "copyright": "Copyright der FHIR-technischen Aufbereitung und Zusammenstellung: HL7 Deutschland e.V. DRG-bezogene Begriffsbestimmungen basieren auf den Deutschen Kodierrichtlinien; Copyright und Nutzungsbedingungen der Deutschen Kodierrichtlinien liegen bei der InEK GmbH.",
   "valueSet": "http://fhir.de/ValueSet/KontaktDiagnoseProzedur",
   "compositional": false,
   "count": 9

--- a/resources/fsh-generated/resources/CodeSystem-Kontaktebene.json
+++ b/resources/fsh-generated/resources/CodeSystem-Kontaktebene.json
@@ -45,5 +45,6 @@
   },
   "caseSensitive": true,
   "valueSet": "http://fhir.de/ValueSet/kontaktebene-de",
+  "copyright": "HL7 Deutschland e.V.",
   "count": 3
 }

--- a/resources/fsh-generated/resources/CodeSystem-VersichertenartPKV.json
+++ b/resources/fsh-generated/resources/CodeSystem-VersichertenartPKV.json
@@ -41,5 +41,6 @@
   "caseSensitive": true,
   "valueSet": "http://fhir.de/ValueSet/pkv/Versichertenart",
   "compositional": false,
+  "copyright": "HL7 Deutschland e.V.",
   "count": 2
 }

--- a/resources/fsh-generated/resources/CodeSystem-WirkstofftypCS.json
+++ b/resources/fsh-generated/resources/CodeSystem-WirkstofftypCS.json
@@ -63,5 +63,6 @@
   },
   "caseSensitive": true,
   "valueSet": "http://fhir.de/ValueSet/WirkstofftypVS",
-  "count": 3
+  "count": 3,
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-administrative-gender-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-administrative-gender-supplement.json
@@ -64,5 +64,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "http://hl7.org/fhir/administrative-gender"
+  "supplements": "http://hl7.org/fhir/administrative-gender",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-cs-common-meta-tag-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-cs-common-meta-tag-de.json
@@ -34,6 +34,7 @@
     ]
   },
   "valueSet": "http://fhir.de/ValueSet/common-meta-tag-de",
+  "copyright": "HL7 Deutschland e.V.",
   "caseSensitive": true,
   "count": 1
 }

--- a/resources/fsh-generated/resources/CodeSystem-cs-merkzeichen-de.json
+++ b/resources/fsh-generated/resources/CodeSystem-cs-merkzeichen-de.json
@@ -106,5 +106,6 @@
   ],
   "caseSensitive": true,
   "valueSet": "http://fhir.de/ValueSet/merkzeichen-de",
+  "copyright": "Die Merkzeichen beruhen auf gesetzlichen bzw. untergesetzlichen Vorgaben des deutschen Sozialrechts.",
   "count": 14
 }

--- a/resources/fsh-generated/resources/CodeSystem-diagnosis-role-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-diagnosis-role-supplement.json
@@ -91,5 +91,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "http://terminology.hl7.org/CodeSystem/diagnosis-role"
+  "supplements": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-icd-10-gm-mehrfachcodierungs-kennzeichen.json
+++ b/resources/fsh-generated/resources/CodeSystem-icd-10-gm-mehrfachcodierungs-kennzeichen.json
@@ -45,5 +45,6 @@
   },
   "caseSensitive": true,
   "valueSet": "http://fhir.de/ValueSet/icd-10-gm-mehrfachcodierungs-kennzeichen",
+  "copyright": "HL7 Deutschland e.V.",
   "count": 3
 }

--- a/resources/fsh-generated/resources/CodeSystem-identifier-type-v2-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-identifier-type-v2-supplement.json
@@ -73,5 +73,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "http://terminology.hl7.org/CodeSystem/v2-0203"
+  "supplements": "http://terminology.hl7.org/CodeSystem/v2-0203",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-marital-status-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-marital-status-supplement.json
@@ -109,5 +109,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
+  "supplements": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-observation-category-supplement.json
+++ b/resources/fsh-generated/resources/CodeSystem-observation-category-supplement.json
@@ -109,5 +109,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "http://terminology.hl7.org/CodeSystem/observation-category"
+  "supplements": "http://terminology.hl7.org/CodeSystem/observation-category",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/CodeSystem-supplement-iso-3166.json
+++ b/resources/fsh-generated/resources/CodeSystem-supplement-iso-3166.json
@@ -2269,5 +2269,6 @@
       "http://hl7.org/fhir/StructureDefinition/shareablecodesystem|4.0.1"
     ]
   },
-  "supplements": "urn:iso:std:iso:3166"
+  "supplements": "urn:iso:std:iso:3166",
+  "copyright": "HL7 Deutschland e.V."
 }

--- a/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgAbleitungenVS.json
@@ -28,7 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
   "compose": {
     "include": [
       {

--- a/resources/fsh-generated/resources/ValueSet-EkgLeads.json
+++ b/resources/fsh-generated/resources/ValueSet-EkgLeads.json
@@ -28,7 +28,6 @@
       }
     }
   ],
-  "copyright": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.",
   "compose": {
     "include": [
       {

--- a/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
+++ b/resources/fsh-generated/resources/ValueSet-ValueSetVitalSignDE-Body-Height-Loinc.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -45,6 +39,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Atemfrequenz-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -53,6 +47,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Length-UCUM.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -49,6 +43,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Body-Weigth-UCUM.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -49,6 +43,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Herzfrequenz-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -46,6 +40,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergewicht-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -46,6 +40,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpergroesse-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -46,6 +40,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Koerpertemperatur-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -87,6 +81,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Kopfumfang-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -53,6 +47,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
+++ b/resources/fsh-generated/resources/ValueSet-VitalSignDE-Sauerstoffsaettigung-SNOMED-CT.json
@@ -28,12 +28,6 @@
       }
     }
   ],
-  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.",
-  "meta": {
-    "profile": [
-      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
-    ]
-  },
   "compose": {
     "include": [
       {
@@ -49,6 +43,11 @@
           }
         ]
       }
+    ]
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset|4.0.1"
     ]
   }
 }

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-eye.json
@@ -25,12 +25,15 @@
       }
     }
   ],
-  "name": "VS_Score_GlasgowComaScore_Eye",
-  "title": "VS Score Glasgow Coma Score Eye",
-  "description": "Dieses ValueSet enthält die Codes für die Augenöffnungs-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung dieses Teilaspekts der neurologischen Beurteilung.",
   "compose": {
     "include": [
       {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.compose.include.copyright",
+            "valueString": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
+          }
+        ],
         "system": "http://loinc.org",
         "concept": [
           {
@@ -76,5 +79,8 @@
         ]
       }
     ]
-  }
+  },
+  "name": "VS_Score_GlasgowComaScore_Eye",
+  "title": "VS Score Glasgow Coma Score Eye",
+  "description": "Dieses ValueSet enthält die Codes für die Augenöffnungs-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung dieses Teilaspekts der neurologischen Beurteilung."
 }

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-motor.json
@@ -25,12 +25,15 @@
       }
     }
   ],
-  "name": "VS_Score_GlasgowComaScore_Motor",
-  "title": "VS Score Glasgow Coma Score Motor",
-  "description": "Dieses ValueSet enthält die Codes für die motorische Reaktions-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der motorischen Antwort.",
   "compose": {
     "include": [
       {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.compose.include.copyright",
+            "valueString": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
+          }
+        ],
         "system": "http://loinc.org",
         "concept": [
           {
@@ -96,5 +99,8 @@
         ]
       }
     ]
-  }
+  },
+  "name": "VS_Score_GlasgowComaScore_Motor",
+  "title": "VS Score Glasgow Coma Score Motor",
+  "description": "Dieses ValueSet enthält die Codes für die motorische Reaktions-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der motorischen Antwort."
 }

--- a/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
+++ b/resources/fsh-generated/resources/ValueSet-glasgow-coma-score-verbal.json
@@ -25,12 +25,15 @@
       }
     }
   ],
-  "name": "VS_Score_GlasgowComaScore_Verbal",
-  "title": "VS Score Glasgow Coma Score Verbal",
-  "description": "Dieses ValueSet enthält die Codes für die verbale Kommunikations-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der verbalen Reaktion.",
   "compose": {
     "include": [
       {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.compose.include.copyright",
+            "valueString": "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
+          }
+        ],
         "system": "http://loinc.org",
         "concept": [
           {
@@ -86,5 +89,8 @@
         ]
       }
     ]
-  }
+  },
+  "name": "VS_Score_GlasgowComaScore_Verbal",
+  "title": "VS Score Glasgow Coma Score Verbal",
+  "description": "Dieses ValueSet enthält die Codes für die verbale Kommunikations-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der verbalen Reaktion."
 }

--- a/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
+++ b/resources/fsh-generated/resources/ValueSet-valueset-wg14.json
@@ -33,7 +33,6 @@
       }
     }
   ],
-  "copyright": "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH",
   "compose": {
     "include": [
       {

--- a/resources/input/fsh/codesystems/CS_CommonMetaTag_De.fsh
+++ b/resources/input/fsh/codesystems/CS_CommonMetaTag_De.fsh
@@ -7,5 +7,6 @@ Description: "Dieses CodeSystem enthält gebräuchliche Metadaten-Tags zur Kennz
 * ^content = #complete
 * ^url = "http://fhir.de/CodeSystem/common-meta-tag-de"
 * ^valueSet = "http://fhir.de/ValueSet/common-meta-tag-de"
+* ^copyright = "HL7 Deutschland e.V."
 * ^caseSensitive = true
 * #external "External" "Informationen welche in der Ressource abgebildet werden stammen aus einem externen, potentiell unverifizierten System"

--- a/resources/input/fsh/codesystems/CodeSystemSupplementISO3166.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemSupplementISO3166.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt ISO 3166 um deutschsprachige
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "urn:iso:std:iso:3166"
+* ^copyright = "HL7 Deutschland e.V."
 * #AF
   * ^designation[+].language = #de-DE
   * ^designation[=].value = "Afghanistan"

--- a/resources/input/fsh/codesystems/CodeSystemVersichertenartPKV.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemVersichertenartPKV.fsh
@@ -9,6 +9,7 @@ Description: "Dieses CodeSystem differenziert die Versichertenart im Kontext pri
 * ^valueSet = "http://fhir.de/ValueSet/pkv/Versichertenart"
 * ^compositional = false
 * ^content = #complete
+* ^copyright = "HL7 Deutschland e.V."
 
 * #VN "Versicherungsnehmer"
   * ^definition = """

--- a/resources/input/fsh/codesystems/CodeSystemWirkstofftyp.fsh
+++ b/resources/input/fsh/codesystems/CodeSystemWirkstofftyp.fsh
@@ -8,6 +8,7 @@ Description: "Dieses CodeSystem unterscheidet Wirkstoffe nach fachlicher Granula
 * ^caseSensitive = true
 * ^valueSet = Canonical(WirkstofftypVS)
 * ^count = 3
+* ^copyright = "HL7 Deutschland e.V."
 * #IN "ingredient" "The name of the substance."
 * #IN ^designation.language = #de-DE
 * #IN ^designation.value = "Wirkstoff allgemein"

--- a/resources/input/fsh/codesystems/DiagnosisRole.fsh
+++ b/resources/input/fsh/codesystems/DiagnosisRole.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt das HL7-CodeSystem `diagnosi
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "http://terminology.hl7.org/CodeSystem/diagnosis-role"
+* ^copyright = "HL7 Deutschland e.V."
 * #AD
   * ^designation.language = #de-DE
   * ^designation.value = "Aufnahmediagnose"

--- a/resources/input/fsh/codesystems/KontaktArtDe.fsh
+++ b/resources/input/fsh/codesystems/KontaktArtDe.fsh
@@ -10,6 +10,7 @@ Description: "Dieses CodeSystem klassifiziert die Art eines Kontakts mit einer G
 * ^hierarchyMeaning = #is-a
 * ^compositional = false
 * ^content = #complete
+* ^copyright = "HL7 Deutschland e.V."
 * #begleitperson "Begleitperson" "Begleitperson definiert nach § 11 Abs. 3 SGB V"
 * #vorstationaer "Vorstationär" "Vorstationärer Kontakt nach § 115 a SGB V"
 * #nachstationaer "Nachstationär" "Nachstationärer Kontakt nach § 115 a SGB V"

--- a/resources/input/fsh/codesystems/KontaktDiagnoseProzedur.fsh
+++ b/resources/input/fsh/codesystems/KontaktDiagnoseProzedur.fsh
@@ -9,6 +9,7 @@ Description: "Dieses CodeSystem beschreibt fachliche Rollen von Diagnosen und Pr
 * ^copyright = "HL7 Deutschland e.V."
 * ^valueSet = "http://fhir.de/ValueSet/KontaktDiagnoseProzedur"
 * ^compositional = false
+* ^copyright = "Copyright der FHIR-technischen Aufbereitung und Zusammenstellung: HL7 Deutschland e.V. DRG-bezogene Begriffsbestimmungen basieren auf den Deutschen Kodierrichtlinien; Copyright und Nutzungsbedingungen der Deutschen Kodierrichtlinien liegen bei der InEK GmbH."
 * #referral-diagnosis "Überweisungsdiagnose" "Die Einweisungsdiagnose/Überweisungsdiagnose ist die Verdachtsdiagnose oder Arbeitsdiagnose, die ein Arzt oder eine Ärztin beim Einweisen/Überweisen eines Patienten in ein Krankenhaus stellt."
 * #treatment-diagnosis "Behandlungsrelevante Diagnosen" "Alle medizinischen Diagnosen, die Einfluss auf die Diagnostik, Therapie, Pflege oder den Verlauf der Behandlung haben."
 * #surgery-diagnosis "Operationsdiagnose" "Eine Operationsdiagnose bezeichnet die spezifische medizinische Diagnose, die den unmittelbaren Anlass für eine durchgeführte Operation darstellt. Sie beschreibt die Erkrankung oder Verletzung, die chirurgisch behandelt wurde, und wird oft im Rahmen der Operationsdokumentation, der Abrechnung sowie für statistische und medizinische Auswertungen angegeben, vgl. §630f BGB Dokumentation der Behandlung"

--- a/resources/input/fsh/codesystems/Kontaktebene.fsh
+++ b/resources/input/fsh/codesystems/Kontaktebene.fsh
@@ -7,6 +7,7 @@ Description: "Dieses CodeSystem beschreibt die Ebene, auf der ein Kontakt mit ei
 * ^caseSensitive = true
 * ^valueSet = "http://fhir.de/ValueSet/kontaktebene-de"
 * ^content = #complete
+* ^copyright = "HL7 Deutschland e.V."
 * #einrichtungskontakt "Einrichtungskontakt" "Beschreibt den Kontakt zur Einrichtung."
 * #abteilungskontakt "Abteilungskontakt" "Beschreibt den Kontakt zur Abteilung."
 * #versorgungsstellenkontakt "Versorgungsstellenkontakt" "Beschreibt den Kontakt zur Versorgungsstelle."

--- a/resources/input/fsh/codesystems/MehrfachkodierungsKennzeichen.fsh
+++ b/resources/input/fsh/codesystems/MehrfachkodierungsKennzeichen.fsh
@@ -7,6 +7,7 @@ Description: "Dieses CodeSystem enthält Zusatzkennzeichen für postkoordinierte
 * ^caseSensitive = true
 * ^valueSet = "http://fhir.de/ValueSet/icd-10-gm-mehrfachcodierungs-kennzeichen"
 * ^content = #complete
+* ^copyright = "HL7 Deutschland e.V."
 * #* "*" "Manifestation"
 * #† "†" "Ätiologie"
 * #! "!" "Zusatzinformation"

--- a/resources/input/fsh/codesystems/Merkzeichen.fsh
+++ b/resources/input/fsh/codesystems/Merkzeichen.fsh
@@ -10,6 +10,7 @@ Description: "Dieses CodeSystem enthält die in Deutschland auf Schwerbehinderte
 * ^content = #complete
 * ^caseSensitive = true
 * ^valueSet = "http://fhir.de/ValueSet/merkzeichen-de"
+* ^copyright = "Die Merkzeichen beruhen auf gesetzlichen bzw. untergesetzlichen Vorgaben des deutschen Sozialrechts."
 * #G "erhebliche Gehbehinderung" "erhebliche Gehbehinderung"
 * #aG "außergewöhnliche Gehbehinderung" "außergewöhnliche Gehbehinderung"
 * #H "Hilflosigkeit" "Hilflosigkeit"

--- a/resources/input/fsh/codesystems/SupplementAdministrativeGender.fsh
+++ b/resources/input/fsh/codesystems/SupplementAdministrativeGender.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt `AdministrativeGender` um de
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "http://hl7.org/fhir/administrative-gender"
+* ^copyright = "HL7 Deutschland e.V."
 * #male
   * ^designation.language = #de-DE
   * ^designation.value = "männlich"

--- a/resources/input/fsh/codesystems/SupplementIdentifierTypeV2.fsh
+++ b/resources/input/fsh/codesystems/SupplementIdentifierTypeV2.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt das HL7-v2-CodeSystem für I
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "http://terminology.hl7.org/CodeSystem/v2-0203"
+* ^copyright = "HL7 Deutschland e.V."
 * #DL
   * ^designation.language = #de-DE
   * ^designation.value = "Führerscheinnummer"

--- a/resources/input/fsh/codesystems/SupplementMaritalStatus.fsh
+++ b/resources/input/fsh/codesystems/SupplementMaritalStatus.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt `v3-MaritalStatus` um deutsc
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
+* ^copyright = "HL7 Deutschland e.V."
 * #A
   * ^designation.language = #de-DE
   * ^designation.value = "annulliert"

--- a/resources/input/fsh/codesystems/SupplementObservationCategory.fsh
+++ b/resources/input/fsh/codesystems/SupplementObservationCategory.fsh
@@ -6,6 +6,7 @@ Description: "Dieses CodeSystem-Supplement ergänzt `ObservationCategoryCodes` u
 * ^meta.profile = $shareablecodesystem
 * ^content = #supplement
 * ^supplements = "http://terminology.hl7.org/CodeSystem/observation-category"
+* ^copyright = "HL7 Deutschland e.V."
 * #social-history
   * ^designation.language = #de-DE
   * ^designation.value = "Sozialanamnese"

--- a/resources/input/fsh/rulesets.fsh
+++ b/resources/input/fsh/rulesets.fsh
@@ -29,17 +29,25 @@ RuleSet: ArtifactAuthorInstance(name)
 * extension[+].url = "http://hl7.org/fhir/StructureDefinition/artifact-author"
 * extension[=].valueContactDetail.name = "{name}"
 
+RuleSet: IncludeCopyright(copyright)
+* ^compose.include.extension.url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.compose.include.copyright"
+* ^compose.include.extension.valueString = "{copyright}"
+
+RuleSet: IncludeCopyrightInstance(copyright)
+* compose.include.extension.url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.compose.include.copyright"
+* compose.include.extension.valueString = "{copyright}"
+
 RuleSet: SnomedDisclaimer
 * insert ArtifactAuthor([[International Health Terminology Standards Development Organisation (IHTSDO)]])
-* ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement."
+* insert IncludeCopyright([[This value set includes content from SNOMED CT, which is copyright © 2002 International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.]])
 
 RuleSet: UCUMDisclaimer
 * insert ArtifactAuthor([[Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization]])
-* ^copyright = "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved."
+* insert IncludeCopyright([[The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright © 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved.]])
 
 RuleSet: LOINCDisclaimer
 * insert ArtifactAuthor([[Regenstrief Institute, Inc. and the LOINC Committee]])
-* ^copyright = "This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use."
+* insert IncludeCopyright([[This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.]])
 
 RuleSet: VitalSignDESlicingWithLoinc
 * coding

--- a/resources/input/fsh/valuesets/AbrechnungsDiagnoseProzedur.fsh
+++ b/resources/input/fsh/valuesets/AbrechnungsDiagnoseProzedur.fsh
@@ -4,6 +4,7 @@ Title: "AbrechnungsDiagnoseProzedur ValueSet"
 Description: "Dieses ValueSet bündelt Diagnose-Rollen, die speziell für Abrechnungszwecke relevant sind. Es dient der klaren Kennzeichnung, welche Diagnosen oder Prozedurbezüge für die Fallabrechnung maßgeblich sind."
 * insert Meta
 * ^meta.profile = $shareablevalueset
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * KontaktDiagnoseProzedur#principle-DRG "Principle-DRG"
 * KontaktDiagnoseProzedur#secondary-DRG "Secondary-DRG"
 * KontaktDiagnoseProzedur#hospital-main-diagnosis "Krankenhaus Hauptdiagnose"

--- a/resources/input/fsh/valuesets/DiagnoseTyp.fsh
+++ b/resources/input/fsh/valuesets/DiagnoseTyp.fsh
@@ -3,5 +3,6 @@ Id: DiagnoseTyp
 Title: "DiagnoseTyp ValueSet"
 Description: "Dieses ValueSet enthält übergeordnete Typen diagnostischer Angaben, etwa Einweisungs- oder behandlungsrelevante Diagnosen. Es dient der fachlichen Einordnung, in welchem Versorgungskontext eine Diagnose erhoben oder verwendet wird."
 * insert Meta
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * KontaktDiagnoseProzedur#referral-diagnosis "Einweisungs-/Überweisungsdiagnose"
 * KontaktDiagnoseProzedur#treatment-diagnosis "Behandlungsrelevante Diagnosen"

--- a/resources/input/fsh/valuesets/Diagnosesubtyp.fsh
+++ b/resources/input/fsh/valuesets/Diagnosesubtyp.fsh
@@ -3,6 +3,7 @@ Id: Diagnosesubtyp
 Title: "Diagnosesubtyp ValueSet"
 Description: "Dieses ValueSet bündelt spezielle Untertypen von Diagnosen mit definierter fachlicher Rolle, etwa Operationsdiagnosen, Todesursachen oder Aufnahmediagnosen. Es dient der semantischen Verfeinerung diagnostischer Angaben innerhalb eines Versorgungskontexts."
 * insert Meta
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * KontaktDiagnoseProzedur#surgery-diagnosis "Operationsdiagnose"
 * KontaktDiagnoseProzedur#department-main-diagnosis "Abteilung Hauptdiagnose"
 * KontaktDiagnoseProzedur#cause-of-death "Todesursache"

--- a/resources/input/fsh/valuesets/GenderOtherDE.fsh
+++ b/resources/input/fsh/valuesets/GenderOtherDE.fsh
@@ -5,5 +5,6 @@ Description: "Dieses ValueSet enthält die nicht-binären beziehungsweise nicht 
 * insert Meta
 * ^meta.profile = $shareablevalueset
 * ^url = "http://fhir.de/ValueSet/gender-other-de"
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * GenderAmtlichDE#D "divers"
 * GenderAmtlichDE#X "unbestimmt"

--- a/resources/input/fsh/valuesets/IdentifierTypeDeBasis.fsh
+++ b/resources/input/fsh/valuesets/IdentifierTypeDeBasis.fsh
@@ -13,3 +13,4 @@ Description: "Dieses ValueSet bündelt die im deutschen Basisprofil zulässigen 
 * $v2-0203#AN "Account number"
 * $v2-0203#PRN "Provider number"
 * include codes from system IdentifierTypeDeBasis
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])

--- a/resources/input/fsh/valuesets/IdentifierTypeKvidDeBasis.fsh
+++ b/resources/input/fsh/valuesets/IdentifierTypeKvidDeBasis.fsh
@@ -4,6 +4,7 @@ Title: "Identifier Type Kvid DeBasis ValueSet"
 Description: "Dieses ValueSet enthält die für KVID-bezogene Identifier zulässigen Typcodes. Es dient der eindeutigen Kennzeichnung von Versicherungs- und Krankenversichertennummern im deutschen Kontext."
 * insert Meta
 * ^meta.profile = $shareablevalueset
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * $identifier-type-de-basis#GKV "Gesetzliche Krankenversicherung"
 * $identifier-type-de-basis#PKV "Private Krankenversicherung"
 * $identifier-type-de-basis#KVZ10 "Krankenversichertennummer"

--- a/resources/input/fsh/valuesets/OPS-SNOMED-Source-CodesVS.fsh
+++ b/resources/input/fsh/valuesets/OPS-SNOMED-Source-CodesVS.fsh
@@ -3,6 +3,7 @@ Id: ValueSet-OPS-SNOMED-Source-Codes
 Title: "ValueSet of OPS Source Codes for the OPS-SNOMED ConceptMap"
 Description: "Dieses ValueSet enthält die Quellkonzepte aus dem ConceptMap-Mapping zwischen OPS-Kategorien und SNOMED CT. Es dient der klaren Abgrenzung der abgebildeten OPS-Ausgangswerte für Terminologie-Transformationen."
 * insert Meta
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * $ops#1 "Diagnostische Maßnahmen"
 * $ops#3 "Bildgebende Diagnostik"
 * $ops#5 "Operationen"

--- a/resources/input/fsh/valuesets/PflegegradDE.fsh
+++ b/resources/input/fsh/valuesets/PflegegradDE.fsh
@@ -27,3 +27,4 @@ Description: "Dieses ValueSet enthält OPS-Codes zur Differenzierung des dokumen
 * ^expansion.contains[=].code = #9-984.b
 * ^expansion.contains[=].display = "Pflegebedürftigkeit: Erfolgter Antrag auf Einstufung in einen Pflegegrad"
 * include codes from system $ops where parent = "9-984"
+* insert IncludeCopyright([[Bundesinstitut für Arzneimittel und Medizinprodukte (BfArM)]])

--- a/resources/input/fsh/valuesets/ScoreDE_GCS.fsh
+++ b/resources/input/fsh/valuesets/ScoreDE_GCS.fsh
@@ -3,6 +3,7 @@ InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
 * insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
+* insert IncludeCopyrightInstance([[This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.]])
 * name = "VS_Score_GlasgowComaScore_Eye"
 * title = "VS Score Glasgow Coma Score Eye"
 * description = "Dieses ValueSet enthält die Codes für die Augenöffnungs-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung dieses Teilaspekts der neurologischen Beurteilung."
@@ -29,6 +30,7 @@ InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
 * insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
+* insert IncludeCopyrightInstance([[This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.]])
 * name = "VS_Score_GlasgowComaScore_Verbal"
 * title = "VS Score Glasgow Coma Score Verbal"
 * description = "Dieses ValueSet enthält die Codes für die verbale Kommunikations-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der verbalen Reaktion."
@@ -59,6 +61,7 @@ InstanceOf: ValueSet
 Usage: #definition
 * insert Meta-Instance
 * insert ArtifactAuthorInstance([[Regenstrief Institute, Inc. and the LOINC Committee]])
+* insert IncludeCopyrightInstance([[This content from LOINC® is copyright © 1995 Regenstrief Institute, Inc. and the LOINC Committee, and available at no cost under the license at http://loinc.org/terms-of-use.]])
 * name = "VS_Score_GlasgowComaScore_Motor"
 * title = "VS Score Glasgow Coma Score Motor"
 * description = "Dieses ValueSet enthält die Codes für die motorische Reaktions-Komponente des Glasgow Coma Score. Es dient der standardisierten, ordinal auswertbaren Erfassung der motorischen Antwort."

--- a/resources/input/fsh/valuesets/VersicherungsartDeBasis.fsh
+++ b/resources/input/fsh/valuesets/VersicherungsartDeBasis.fsh
@@ -4,6 +4,7 @@ Description: "Dieses ValueSet enthält die im deutschen Kontext zulässigen Vers
 * insert Meta
 * ^meta.profile = $shareablevalueset
 * ^url = "http://fhir.de/ValueSet/versicherungsart-de-basis"
+* insert IncludeCopyright([[HL7 Deutschland e.V.]])
 * include codes from system VersicherungsartDeBasis
 * include codes from system $KBV_CS_FOR_Payor_type
 * $v3-NullFlavor#UNK

--- a/resources/input/fsh/valuesets/WG14.fsh
+++ b/resources/input/fsh/valuesets/WG14.fsh
@@ -7,5 +7,4 @@ Description: "Deprecated - Dieses  ValueSet referenziert die ehemalige ABDATA-WG
 * ^status = #retired
 * ^url = "http://fhir.de/ValueSet/abdata/wg14"
 * insert ArtifactAuthor([[ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH]])
-* ^copyright = "ABDATA Pharma-Daten-Service der Avoxa - Mediengruppe Deutscher Apotheker GmbH"
 * include codes from system WG14


### PR DESCRIPTION
This pull request updates several FHIR CodeSystem and ValueSet JSON resources to improve copyright attribution and metadata consistency. The main changes involve adding or updating copyright statements to reflect proper ownership and legal requirements, as well as reorganizing some metadata fields for better alignment with FHIR standards.

**Copyright attribution updates:**

* Added or updated the `"copyright"` field in multiple `CodeSystem` resources to properly attribute HL7 Deutschland e.V. or other relevant organizations, and to clarify licensing for DRG-related and legal content. [[1]](diffhunk://#diff-b23cff15808af36db96f317466e17ab77d4b8b3b7f131799519fe76ab78eafe1R95) [[2]](diffhunk://#diff-276add9fc171c4b0a296c9b8902e7d2120917a404c9f5df5fdcc11afaea07b4eL77-R77) [[3]](diffhunk://#diff-a269ab7f1aedaecf4a9beba03fd4912c8daf0ae49807f73dbbc3c4e0fce001b8R48) [[4]](diffhunk://#diff-52922935c433c7ff020226e09cf4309ee7ddb05ca352241f43b68c7c509a8571R44) [[5]](diffhunk://#diff-b37b29696d64c0905d7f42d012462d775cf7005fd9763947286a50330a9391c4L66-R67) [[6]](diffhunk://#diff-8031de86c9e86e1ac30371a6bf93172f1facc13c592c1a14b39cb3c5f6524711R37) [[7]](diffhunk://#diff-028f7b96774f57d784f2ba49dd0c69777a9e20dfcbf70a5c2a3bf2805294f1a8R109) [[8]](diffhunk://#diff-18e253888c55799524bd1b7aae80cac33e79c94c1e3d744d0d9c3192c6187ee2R48) [[9]](diffhunk://#diff-556cc1847de7817193b0cde1f85c9a363b61abf38ee0eacff04a108211514a82L67-R68) [[10]](diffhunk://#diff-20d4b453e6ad1f12e5f717a18e50321f2ec6c8cfc19be711eca4443e55d5da6bL94-R95) [[11]](diffhunk://#diff-32f61257b12a4ae2614973044957d421276234ddbdedac85bdd2e7f53aa65591L76-R77) [[12]](diffhunk://#diff-330515d446d2b1d95b190090646d253f0e2928413701d1d9a6d31c06de87e192L112-R113) [[13]](diffhunk://#diff-f6c594be86b7d655e08282cf02ac31bc553ae1be3751885fb4626c377a09104bL112-R113) [[14]](diffhunk://#diff-17d5881688d9f58cda7a8a1533c0c57f5b32bdb63dca5058bd163942845600afL2272-R2273)

* Updated or removed copyright statements in several `ValueSet` resources to ensure accurate representation of third-party content and licensing (e.g., SNOMED CT, LOINC, UCUM). [[1]](diffhunk://#diff-00f81dbbb35f5df9022c0dd7bd95bcc027eda9c697fffb0385fc3dc7603d20a8L31) [[2]](diffhunk://#diff-497ab6397040d5b3185dd26d29ff38b8f4f3a791fdfd9d3175f3baca8988ae4fL31) [[3]](diffhunk://#diff-d0508e7ea7d10e1a1ee113461f7da3b483c727e20fae768b5c3c249285f165c0L31-L36) [[4]](diffhunk://#diff-ed3f82dc5115765b85ee881ea6ddf58ed3b354be636b9a0ee7f8af467672d365L31-L36) [[5]](diffhunk://#diff-fed3467f80465a45b4ec0a43ed822cfeeea2f63921c9a7812524ae79a25576edL31-L36) [[6]](diffhunk://#diff-a811bd247815f6a4ec6e2b57936a575f7cd7386935bab4c86e92c8141a3f8e0cL31-L36)

**Metadata and structure improvements:**

* Reorganized the placement of the `"meta"` field and ensured the `"profile"` information is correctly included in relevant `ValueSet` resources, aligning with FHIR best practices. [[1]](diffhunk://#diff-d0508e7ea7d10e1a1ee113461f7da3b483c727e20fae768b5c3c249285f165c0R43-R47) [[2]](diffhunk://#diff-ed3f82dc5115765b85ee881ea6ddf58ed3b354be636b9a0ee7f8af467672d365R51-R55) [[3]](diffhunk://#diff-fed3467f80465a45b4ec0a43ed822cfeeea2f63921c9a7812524ae79a25576edR47-R51) [[4]](diffhunk://#diff-a811bd247815f6a4ec6e2b57936a575f7cd7386935bab4c86e92c8141a3f8e0cR47-R51)

These changes ensure legal compliance, improve clarity of resource ownership, and enhance the structure and interoperability of the FHIR artifacts.